### PR TITLE
Added Dockerfile and .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+**/__pycache__/
+**/.coverage
+**/README
+**/coverage.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-alpine
+
+WORKDIR /usr/app
+
+RUN pip install poetry
+
+COPY poetry.lock pyproject.toml alembic.ini ./
+
+RUN poetry config virtualenvs.create false
+RUN poetry install --no-root
+
+COPY ./src ./src
+COPY ./db_revisions ./db_revisions
+
+WORKDIR /usr/app/src
+
+EXPOSE 8888
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8888"]


### PR DESCRIPTION
Closes #15 

To test, run the following commands from the root of the repo:
- `docker build -t filing-api .`
- `docker run -it -d --name current-filing-api -p 8383:8888 filing-api`
- `curl -v localhost:8383/v1/filing/123/submissions/1 -F 'file=@./alembic.ini'`  (currently this endpoint doesn't do anything so this is just showing we can hit it, you can use any file here)
- `docker logs current-filing-api` to verify a 202 Accepted was received

