### PR TITLE
40 create filing period get route

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -545,6 +545,51 @@ files = [
 ]
 
 [[package]]
+name = "httpcore"
+version = "1.0.2"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "httpcore-1.0.2-py3-none-any.whl", hash = "sha256:096cc05bca73b8e459a1fc3dcf585148f63e534eae4339559c9b8a8d6399acc7"},
+    {file = "httpcore-1.0.2.tar.gz", hash = "sha256:9fc092e4799b26174648e54b74ed5f683132a464e95643b226e00c2ed2fa6535"},
+]
+
+[package.dependencies]
+certifi = "*"
+h11 = ">=0.13,<0.15"
+
+[package.extras]
+asyncio = ["anyio (>=4.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<0.23.0)"]
+
+[[package]]
+name = "httpx"
+version = "0.26.0"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "httpx-0.26.0-py3-none-any.whl", hash = "sha256:8915f5a3627c4d47b73e8202457cb28f1266982d1159bd5779d86a80c0eab1cd"},
+    {file = "httpx-0.26.0.tar.gz", hash = "sha256:451b55c30d5185ea6b23c2c793abf9bb237d2a7dfb901ced6ff69ad37ec1dfaf"},
+]
+
+[package.dependencies]
+anyio = "*"
+certifi = "*"
+httpcore = "==1.*"
+idna = "*"
+sniffio = "*"
+
+[package.extras]
+brotli = ["brotli", "brotlicffi"]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+
+[[package]]
 name = "idna"
 version = "3.6"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -1760,4 +1805,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "0d84f7a04b289448754ff5e85f159d3d9571c1e68b99a9ac50b87137bd365f95"
+content-hash = "d35945c0f2d1d55b9654f701975784502d01d3f8e17079213ca22b38d40c327d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ ruff = "0.1.6"
 black = "~23.11.0"
 pytest-asyncio = "^0.23.2"
 aiosqlite = "^0.19.0"
+httpx = "^0.26.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/entities/repos/submission_repo.py
+++ b/src/entities/repos/submission_repo.py
@@ -24,6 +24,13 @@ async def get_submissions(session: AsyncSession, filing_id: int = None) -> List[
         return results.all()
 
 
+async def get_filing_periods(session: AsyncSession) -> List[FilingPeriodDAO]:
+    async with session.begin():
+        stmt = select(FilingPeriodDAO)
+        results = await session.scalars(stmt)
+        return results.all()
+
+
 async def get_submission(session: AsyncSession, submission_id: int) -> SubmissionDAO:
     return await query_helper(session, submission_id, SubmissionDAO)
 

--- a/src/routers/filing.py
+++ b/src/routers/filing.py
@@ -1,9 +1,26 @@
 from http import HTTPStatus
-from fastapi import Request, UploadFile, BackgroundTasks
+from fastapi import Depends, Request, UploadFile, BackgroundTasks
 from regtech_api_commons.api import Router
 from services import submission_processor
+from typing import Annotated, List
 
-router = Router()
+from entities.engine import get_session
+from entities.models import FilingPeriodDTO
+from entities.repos import submission_repo as repo
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def set_db(request: Request, session: Annotated[AsyncSession, Depends(get_session)]):
+    request.state.db_session = session
+
+
+router = Router(dependencies=[Depends(set_db)])
+
+
+@router.get("/periods", response_model=List[FilingPeriodDTO])
+async def get_filing_periods(request: Request):
+    return await repo.get_filing_periods(request.state.db_session)
 
 
 @router.post("/{lei}/submissions/{submission_id}", status_code=HTTPStatus.ACCEPTED)

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -16,7 +16,7 @@ def app_fixture(mocker: MockerFixture) -> FastAPI:
 
 
 @pytest.fixture
-def get_institutions_mock(mocker: MockerFixture) -> Mock:
+def get_filing_period_mock(mocker: MockerFixture) -> Mock:
     mock = mocker.patch("entities.repos.submission_repo.get_filing_periods")
     mock.return_value = [
         FilingPeriodDAO(

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -10,9 +10,6 @@ from entities.models import FilingPeriodDAO, FilingType
 
 @pytest.fixture
 def app_fixture(mocker: MockerFixture) -> FastAPI:
-    mocked_engine = mocker.patch("sqlalchemy.ext.asyncio.create_async_engine")
-    MockedEngine = mocker.patch("sqlalchemy.ext.asyncio.AsyncEngine")
-    mocked_engine.return_value = MockedEngine.return_value
     from main import app
 
     return app

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,33 @@
+import pytest
+
+from datetime import datetime
+from fastapi import FastAPI
+from pytest_mock import MockerFixture
+from unittest.mock import Mock
+
+from entities.models import FilingPeriodDAO, FilingType
+
+
+@pytest.fixture
+def app_fixture(mocker: MockerFixture) -> FastAPI:
+    mocked_engine = mocker.patch("sqlalchemy.ext.asyncio.create_async_engine")
+    MockedEngine = mocker.patch("sqlalchemy.ext.asyncio.AsyncEngine")
+    mocked_engine.return_value = MockedEngine.return_value
+    from main import app
+
+    return app
+
+
+@pytest.fixture
+def get_institutions_mock(mocker: MockerFixture) -> Mock:
+    mock = mocker.patch("entities.repos.submission_repo.get_filing_periods")
+    mock.return_value = [
+        FilingPeriodDAO(
+            name="FilingPeriod2024",
+            start_period=datetime.now(),
+            end_period=datetime.now(),
+            due=datetime.now(),
+            filing_type=FilingType.MANUAL,
+        )
+    ]
+    return mock

--- a/tests/api/routers/test_filing_api.py
+++ b/tests/api/routers/test_filing_api.py
@@ -6,7 +6,7 @@ from pytest_mock import MockerFixture
 
 
 class TestFilingApi:
-    def test_get_periods(self, mocker: MockerFixture, app_fixture: FastAPI, get_institutions_mock: Mock):
+    def test_get_periods(self, mocker: MockerFixture, app_fixture: FastAPI, get_filing_period_mock: Mock):
         client = TestClient(app_fixture)
         res = client.get("/v1/filing/periods")
         assert res.status_code == 200

--- a/tests/api/routers/test_filing_api.py
+++ b/tests/api/routers/test_filing_api.py
@@ -1,0 +1,14 @@
+from unittest.mock import Mock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pytest_mock import MockerFixture
+
+
+class TestFilingApi:
+    def test_get_periods(self, mocker: MockerFixture, app_fixture: FastAPI, get_institutions_mock: Mock):
+        client = TestClient(app_fixture)
+        res = client.get("/v1/filing/periods")
+        assert res.status_code == 200
+        assert len(res.json()) == 1
+        assert res.json()[0]["name"] == "FilingPeriod2024"

--- a/tests/entities/repos/test_submission_repo.py
+++ b/tests/entities/repos/test_submission_repo.py
@@ -85,6 +85,11 @@ class TestSubmissionRepo:
         assert res.id == 2
         assert res.filing_type == FilingType.MANUAL
 
+    async def test_get_filing_periods(self, query_session: AsyncSession):
+        res = await repo.get_filing_periods(query_session)
+        assert len(res) == 1
+        assert res[0].name == "FilingPeriod2024"
+
     async def test_get_filing_period(self, query_session: AsyncSession):
         res = await repo.get_filing_period(query_session, filing_period_id=1)
         assert res.id == 1


### PR DESCRIPTION
Closes #40

- Added /periods route to filing.py, along with the supporting get_session function for db connections
- Added get_filing_periods function to submission_repo to return all FilingPeriod objects in the db
- Added pytests for the route and the new submission_repo function