### PR TITLE
Added Oauth2/Keycloak configs, decorators

### DIFF
--- a/db_revisions/env.py
+++ b/db_revisions/env.py
@@ -30,13 +30,13 @@ if ENV == "LOCAL":
 else:
     load_dotenv()
 
-INST_DB_USER = os.environ.get("INST_DB_USER")
-INST_DB_PWD = os.environ.get("INST_DB_PWD")
-INST_DB_HOST = os.environ.get("INST_DB_HOST")
-INST_DB_NAME = os.environ.get("INST_DB_NAME")
-INST_DB_SCHEMA = os.environ.get("INST_DB_SCHEMA")
-INST_CONN = f"postgresql://{INST_DB_USER}:{(parse.quote(INST_DB_PWD, safe='')).replace('%', '%%')}@{INST_DB_HOST}/{INST_DB_NAME}"
-config.set_main_option("sqlalchemy.url", INST_CONN)
+DB_USER = os.environ.get("DB_USER")
+DB_PWD = os.environ.get("DB_PWD")
+DB_HOST = os.environ.get("DB_HOST")
+DB_NAME = os.environ.get("DB_NAME")
+DB_SCHEMA = os.environ.get("DB_SCHEMA")
+CONN = f"postgresql://{DB_USER}:{(parse.quote(DB_PWD, safe='')).replace('%', '%%')}@{DB_HOST}/{DB_NAME}"
+config.set_main_option("sqlalchemy.url", CONN)
 
 # end specific SBL configuration
 
@@ -45,7 +45,7 @@ config.set_main_option("sqlalchemy.url", INST_CONN)
 # from myapp import mymodel
 
 target_metadata = Base.metadata
-target_metadata.schema = INST_DB_SCHEMA
+target_metadata.schema = DB_SCHEMA
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,11 +50,11 @@ addopts = [
   "-rfE",
 ]
 env = [
-  "INST_DB_SCHEMA=main",
-  "INST_DB_USER=user",
-  "INST_DB_PWD=user",
-  "INST_DB_HOST=localhost:5432",
-  "INST_DB_NAME=filing",
+  "DB_SCHEMA=main",
+  "DB_USER=user",
+  "DB_PWD=user",
+  "DB_HOST=localhost:5432",
+  "DB_NAME=filing",
   "KC_URL=http://localhost",
   "KC_REALM=",
   "KC_ADMIN_CLIENT_ID=",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,16 @@ env = [
   "INST_DB_USER=user",
   "INST_DB_PWD=user",
   "INST_DB_HOST=localhost:5432",
-  "INST_DB_NAME=filing"
+  "INST_DB_NAME=filing",
+  "KC_URL=http://localhost",
+  "KC_REALM=",
+  "KC_ADMIN_CLIENT_ID=",
+  "KC_ADMIN_CLIENT_SECRET=",
+  "KC_REALM_URL=http://localhost",
+  "AUTH_URL=http://localhost",
+  "TOKEN_URL=http://localhost",
+  "CERTS_URL=http://localhost",
+  "AUTH_CLIENT=",
 ]
 testpaths = ["tests"]
 

--- a/src/.env.local
+++ b/src/.env.local
@@ -1,5 +1,5 @@
-INST_DB_NAME=filing
-INST_DB_USER=filing_user
-INST_DB_PWD=filing_user
-INST_DB_HOST=localhost:5432
-INST_DB_SCHEMA=filing
+DB_NAME=filing
+DB_USER=filing_user
+DB_PWD=filing_user
+DB_HOST=localhost:5432
+DB_SCHEMA=filing

--- a/src/.env.template
+++ b/src/.env.template
@@ -1,6 +1,6 @@
-INST_DB_NAME=
-INST_DB_USER=
-INST_DB_PWD=
-INST_DB_HOST=
-INST_DB_SCHEMA=
-# INST_DB_SCHEME= can be used to override postgresql+asyncpg if needed
+DB_NAME=
+DB_USER=
+DB_PWD=
+DB_HOST=
+DB_SCHEMA=
+# DB_SCHEME= can be used to override postgresql+asyncpg if needed

--- a/src/config.py
+++ b/src/config.py
@@ -14,26 +14,26 @@ if os.getenv("ENV", "LOCAL") == "LOCAL":
 
 
 class Settings(BaseSettings):
-    inst_db_schema: str = "public"
-    inst_db_name: str
-    inst_db_user: str
-    inst_db_pwd: str
-    inst_db_host: str
-    inst_db_scheme: str = "postgresql+asyncpg"
-    inst_conn: PostgresDsn | None = None
+    db_schema: str = "public"
+    db_name: str
+    db_user: str
+    db_pwd: str
+    db_host: str
+    db_scheme: str = "postgresql+asyncpg"
+    conn: PostgresDsn | None = None
 
     def __init__(self, **data):
         super().__init__(**data)
 
-    @field_validator("inst_conn", mode="before")
+    @field_validator("conn", mode="before")
     @classmethod
     def build_postgres_dsn(cls, postgres_dsn, info: ValidationInfo) -> Any:
         postgres_dsn = PostgresDsn.build(
-            scheme=info.data.get("inst_db_scheme"),
-            username=info.data.get("inst_db_user"),
-            password=parse.quote(info.data.get("inst_db_pwd"), safe=""),
-            host=info.data.get("inst_db_host"),
-            path=info.data.get("inst_db_name"),
+            scheme=info.data.get("db_scheme"),
+            username=info.data.get("db_user"),
+            password=parse.quote(info.data.get("db_pwd"), safe=""),
+            host=info.data.get("db_host"),
+            path=info.data.get("db_name"),
         )
         return str(postgres_dsn)
 

--- a/src/config.py
+++ b/src/config.py
@@ -6,6 +6,8 @@ from pydantic import field_validator, ValidationInfo
 from pydantic.networks import PostgresDsn
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from regtech_api_commons.oauth2.config import KeycloakSettings
+
 env_files_to_load = [".env"]
 if os.getenv("ENV", "LOCAL") == "LOCAL":
     env_files_to_load.append(".env.local")
@@ -39,3 +41,5 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
+
+kc_settings = KeycloakSettings(_env_file=env_files_to_load)

--- a/src/entities/engine/engine.py
+++ b/src/entities/engine/engine.py
@@ -6,8 +6,8 @@ from sqlalchemy.ext.asyncio import (
 from asyncio import current_task
 from config import settings
 
-engine = create_async_engine(settings.inst_conn.unicode_string(), echo=True).execution_options(
-    schema_translate_map={None: settings.inst_db_schema}
+engine = create_async_engine(settings.conn.unicode_string(), echo=True).execution_options(
+    schema_translate_map={None: settings.db_schema}
 )
 SessionLocal = async_scoped_session(async_sessionmaker(engine, expire_on_commit=False), current_task)
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,19 @@
 import os
 
 from fastapi import FastAPI
+from fastapi.security import OAuth2AuthorizationCodeBearer
+from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.authentication import AuthenticationMiddleware
+
+from regtech_api_commons.oauth2.oauth2_backend import BearerTokenAuthBackend
+from regtech_api_commons.oauth2.oauth2_admin import OAuth2Admin
 
 from routers import filing_router
 
 from alembic.config import Config
 from alembic import command
+
+from config import kc_settings
 
 app = FastAPI()
 
@@ -17,6 +25,19 @@ async def app_start():
     alembic_cfg.set_main_option("script_location", f"{file_dir}/../db_revisions")
     alembic_cfg.set_main_option("prepend_sys_path", f"{file_dir}/../")
     command.upgrade(alembic_cfg, "head")
+
+
+token_bearer = OAuth2AuthorizationCodeBearer(
+    authorizationUrl=kc_settings.auth_url.unicode_string(), tokenUrl=kc_settings.token_url.unicode_string()
+)
+
+app.add_middleware(AuthenticationMiddleware, backend=BearerTokenAuthBackend(token_bearer, OAuth2Admin(kc_settings)))
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["authorization"],
+)
 
 
 app.include_router(filing_router, prefix="/v1/filing")

--- a/src/routers/filing.py
+++ b/src/routers/filing.py
@@ -10,6 +10,8 @@ from entities.repos import submission_repo as repo
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from starlette.authentication import requires
+
 
 async def set_db(request: Request, session: Annotated[AsyncSession, Depends(get_session)]):
     request.state.db_session = session
@@ -19,6 +21,7 @@ router = Router(dependencies=[Depends(set_db)])
 
 
 @router.get("/periods", response_model=List[FilingPeriodDTO])
+@requires("authenticated")
 async def get_filing_periods(request: Request):
     return await repo.get_filing_periods(request.state.db_session)
 
@@ -33,5 +36,6 @@ async def upload_file(
 
 
 @router.get("/{lei}/filings/{filing_id}/submissions", response_model=List[SubmissionDTO])
+@requires("authenticated")
 async def get_submission(request: Request, lei: str, filing_id: int):
     return await repo.get_submissions(request.state.db_session, filing_id)

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -7,12 +7,41 @@ from unittest.mock import Mock
 
 from entities.models import FilingPeriodDAO, FilingType
 
+from regtech_api_commons.models.auth import AuthenticatedUser
+from starlette.authentication import AuthCredentials, UnauthenticatedUser
+
 
 @pytest.fixture
 def app_fixture(mocker: MockerFixture) -> FastAPI:
     from main import app
 
     return app
+
+
+@pytest.fixture
+def auth_mock(mocker: MockerFixture) -> Mock:
+    return mocker.patch("regtech_api_commons.oauth2.oauth2_backend.BearerTokenAuthBackend.authenticate")
+
+
+@pytest.fixture
+def authed_user_mock(auth_mock: Mock) -> Mock:
+    claims = {
+        "name": "test",
+        "preferred_username": "test_user",
+        "email": "test@local.host",
+        "institutions": "123456ABCDEF, 654321FEDCBA",
+    }
+    auth_mock.return_value = (
+        AuthCredentials(["authenticated"]),
+        AuthenticatedUser.from_claim(claims),
+    )
+    return auth_mock
+
+
+@pytest.fixture
+def unauthed_user_mock(auth_mock: Mock) -> Mock:
+    auth_mock.return_value = (AuthCredentials("unauthenticated"), UnauthenticatedUser())
+    return auth_mock
 
 
 @pytest.fixture

--- a/tests/api/routers/test_filing_api.py
+++ b/tests/api/routers/test_filing_api.py
@@ -8,14 +8,30 @@ from entities.models import SubmissionDAO, SubmissionState
 
 
 class TestFilingApi:
-    def test_get_periods(self, mocker: MockerFixture, app_fixture: FastAPI, get_filing_period_mock: Mock):
+    def test_unauthed_get_periods(
+        self, mocker: MockerFixture, app_fixture: FastAPI, get_filing_period_mock: Mock, unauthed_user_mock: Mock
+    ):
+        client = TestClient(app_fixture)
+        res = client.get("/v1/filing/periods")
+        assert res.status_code == 403
+
+    def test_get_periods(
+        self, mocker: MockerFixture, app_fixture: FastAPI, get_filing_period_mock: Mock, authed_user_mock: Mock
+    ):
         client = TestClient(app_fixture)
         res = client.get("/v1/filing/periods")
         assert res.status_code == 200
         assert len(res.json()) == 1
         assert res.json()[0]["name"] == "FilingPeriod2024"
 
-    async def test_get_submissions(self, mocker: MockerFixture, app_fixture: FastAPI):
+    def test_unauthed_get_submissions(
+        self, mocker: MockerFixture, app_fixture: FastAPI, get_filing_period_mock: Mock, unauthed_user_mock: Mock
+    ):
+        client = TestClient(app_fixture)
+        res = client.get("/v1/filing/123456790/filings/1/submissions")
+        assert res.status_code == 403
+
+    async def test_get_submissions(self, mocker: MockerFixture, app_fixture: FastAPI, authed_user_mock: Mock):
         mock = mocker.patch("entities.repos.submission_repo.get_submissions")
         mock.return_value = [
             SubmissionDAO(

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -3,11 +3,11 @@ from config import Settings
 
 def test_postgres_dsn_building():
     mock_config = {
-        "inst_db_name": "test",
-        "inst_db_user": "user",
-        "inst_db_pwd": "\\z9-/tgb76#@",
-        "inst_db_host": "test:5432",
-        "inst_db_scehma": "test",
+        "db_name": "test",
+        "db_user": "user",
+        "db_pwd": "\\z9-/tgb76#@",
+        "db_host": "test:5432",
+        "db_scehma": "test",
     }
     settings = Settings(**mock_config)
-    assert str(settings.inst_conn) == "postgresql+asyncpg://user:%5Cz9-%2Ftgb76%23%40@test:5432/test"
+    assert str(settings.conn) == "postgresql+asyncpg://user:%5Cz9-%2Ftgb76%23%40@test:5432/test"


### PR DESCRIPTION
Closes #46 

- Updated config.py to pull in KeycloakSettings
- Updated the main.py to instantiate the OAuth2AuthorizationCodeBearer (based on keycloak settings) and setup the FastAPI/Starlette authentication middleware
- Added @requires("authenticated") to our two current GETs
- Added pytest mocks and functions to be able to test unauth'd and auth'd GETs