### PR TITLE
Added /v1/filing/{period_name} endpoint, corresponding repo and pytests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - "main"
-      - "53-adding-get-for-filing-object-endpoints"
 
 jobs:
   unit-tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - "main"
+      - "53-adding-get-for-filing-object-endpoints"
 
 jobs:
   unit-tests:

--- a/poetry.lock
+++ b/poetry.lock
@@ -66,6 +66,17 @@ test = ["anyio[trio]", "coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "mock (>=
 trio = ["trio (<0.22)"]
 
 [[package]]
+name = "async-lru"
+version = "2.0.4"
+description = "Simple LRU cache for asyncio"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "async-lru-2.0.4.tar.gz", hash = "sha256:b8a59a5df60805ff63220b2a0c5b5393da5521b113cd5465a44eb037d81a5627"},
+    {file = "async_lru-2.0.4-py3-none-any.whl", hash = "sha256:ff02944ce3c288c5be660c42dbcca0742b32c3b279d6dceda655190240b99224"},
+]
+
+[[package]]
 name = "async-timeout"
 version = "4.0.3"
 description = "Timeout context manager for asyncio programs"
@@ -175,17 +186,17 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.34.35"
+version = "1.34.41"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">= 3.8"
 files = [
-    {file = "boto3-1.34.35-py3-none-any.whl", hash = "sha256:53897701ab4f307fbcfdade673eae809dfc5eabb6102053c84907aa27de66e53"},
-    {file = "boto3-1.34.35.tar.gz", hash = "sha256:4052031f9ac18924e94be7c30a5f0af5843a4752b8c8cb9034cd978be252b61b"},
+    {file = "boto3-1.34.41-py3-none-any.whl", hash = "sha256:ae1a974c728c076a49392a695102124f650f45361c654bb7c0bef1bb644c52d5"},
+    {file = "boto3-1.34.41.tar.gz", hash = "sha256:9fd66f22a4cdd63165a7a19186fff9b6e3d742e83498ea3f3231bab6ae4bf0f3"},
 ]
 
 [package.dependencies]
-botocore = ">=1.34.35,<1.35.0"
+botocore = ">=1.34.41,<1.35.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.10.0,<0.11.0"
 
@@ -194,13 +205,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.34.35"
+version = "1.34.41"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">= 3.8"
 files = [
-    {file = "botocore-1.34.35-py3-none-any.whl", hash = "sha256:b67b8c865973202dc655a493317ae14b33d115e49ed6960874eb05d950167b37"},
-    {file = "botocore-1.34.35.tar.gz", hash = "sha256:8a2b53ab772584a5f7e2fe1e4a59028b0602cfef8e39d622db7c6b670e4b1ee6"},
+    {file = "botocore-1.34.41-py3-none-any.whl", hash = "sha256:9b5827332da766da487e5a5b14b36e02528be9f2e899f909577afb7001eb441d"},
+    {file = "botocore-1.34.41.tar.gz", hash = "sha256:3a6943c75a0d292ab6e008bce58ee6503776969479f991f5ad03a5d877af29ae"},
 ]
 
 [package.dependencies]
@@ -1190,17 +1201,17 @@ sqlalchemy = "*"
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.23.4"
+version = "0.23.5"
 description = "Pytest support for asyncio"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pytest-asyncio-0.23.4.tar.gz", hash = "sha256:2143d9d9375bf372a73260e4114541485e84fca350b0b6b92674ca56ff5f7ea2"},
-    {file = "pytest_asyncio-0.23.4-py3-none-any.whl", hash = "sha256:b0079dfac14b60cd1ce4691fbfb1748fe939db7d0234b5aba97197d10fbe0fef"},
+    {file = "pytest-asyncio-0.23.5.tar.gz", hash = "sha256:3a048872a9c4ba14c3e90cc1aa20cbc2def7d01c7c8db3777ec281ba9c057675"},
+    {file = "pytest_asyncio-0.23.5-py3-none-any.whl", hash = "sha256:4e7093259ba018d58ede7d5315131d21923a60f8a6e9ee266ce1589685c89eac"},
 ]
 
 [package.dependencies]
-pytest = ">=7.0.0,<8"
+pytest = ">=7.0.0,<9"
 
 [package.extras]
 docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
@@ -1309,13 +1320,13 @@ pycryptodome = ["pyasn1", "pycryptodome (>=3.3.1,<4.0.0)"]
 
 [[package]]
 name = "python-keycloak"
-version = "3.7.0"
+version = "3.8.1"
 description = "python-keycloak is a Python package providing access to the Keycloak API."
 optional = false
 python-versions = ">=3.8,<4.0"
 files = [
-    {file = "python_keycloak-3.7.0-py3-none-any.whl", hash = "sha256:92aa0a7e965cc5422d335c36efa0519f3188d9b8048cc8083f8f6e23c13178a5"},
-    {file = "python_keycloak-3.7.0.tar.gz", hash = "sha256:29eee9490ba354af81fcdf86ec81d840515d8b53002de831715e05d07298886a"},
+    {file = "python_keycloak-3.8.1-py3-none-any.whl", hash = "sha256:2e1f4a6c069fa4423495b51b0e04149fc101f1a83c18ac7a018aa28b775b92d1"},
+    {file = "python_keycloak-3.8.1.tar.gz", hash = "sha256:489e33d3126e07bd594b4d86d2977587935af353d85f136f7abac6561b39d39a"},
 ]
 
 [package.dependencies]
@@ -1391,7 +1402,7 @@ pandera = "^0.18.0"
 type = "git"
 url = "https://github.com/cfpb/regtech-data-validator.git"
 reference = "HEAD"
-resolved_reference = "ca9604b095af7f2fffbb2fd1c0e8e3edbe0df98b"
+resolved_reference = "2e70654f6eae763098891ce954027debf1c57599"
 
 [[package]]
 name = "requests"
@@ -1509,60 +1520,60 @@ files = [
 
 [[package]]
 name = "sqlalchemy"
-version = "2.0.25"
+version = "2.0.27"
 description = "Database Abstraction Library"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "SQLAlchemy-2.0.25-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4344d059265cc8b1b1be351bfb88749294b87a8b2bbe21dfbe066c4199541ebd"},
-    {file = "SQLAlchemy-2.0.25-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6f9e2e59cbcc6ba1488404aad43de005d05ca56e069477b33ff74e91b6319735"},
-    {file = "SQLAlchemy-2.0.25-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84daa0a2055df9ca0f148a64fdde12ac635e30edbca80e87df9b3aaf419e144a"},
-    {file = "SQLAlchemy-2.0.25-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc8b7dabe8e67c4832891a5d322cec6d44ef02f432b4588390017f5cec186a84"},
-    {file = "SQLAlchemy-2.0.25-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:f5693145220517b5f42393e07a6898acdfe820e136c98663b971906120549da5"},
-    {file = "SQLAlchemy-2.0.25-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:db854730a25db7c956423bb9fb4bdd1216c839a689bf9cc15fada0a7fb2f4570"},
-    {file = "SQLAlchemy-2.0.25-cp310-cp310-win32.whl", hash = "sha256:14a6f68e8fc96e5e8f5647ef6cda6250c780612a573d99e4d881581432ef1669"},
-    {file = "SQLAlchemy-2.0.25-cp310-cp310-win_amd64.whl", hash = "sha256:87f6e732bccd7dcf1741c00f1ecf33797383128bd1c90144ac8adc02cbb98643"},
-    {file = "SQLAlchemy-2.0.25-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:342d365988ba88ada8af320d43df4e0b13a694dbd75951f537b2d5e4cb5cd002"},
-    {file = "SQLAlchemy-2.0.25-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f37c0caf14b9e9b9e8f6dbc81bc56db06acb4363eba5a633167781a48ef036ed"},
-    {file = "SQLAlchemy-2.0.25-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa9373708763ef46782d10e950b49d0235bfe58facebd76917d3f5cbf5971aed"},
-    {file = "SQLAlchemy-2.0.25-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d24f571990c05f6b36a396218f251f3e0dda916e0c687ef6fdca5072743208f5"},
-    {file = "SQLAlchemy-2.0.25-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:75432b5b14dc2fff43c50435e248b45c7cdadef73388e5610852b95280ffd0e9"},
-    {file = "SQLAlchemy-2.0.25-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:884272dcd3ad97f47702965a0e902b540541890f468d24bd1d98bcfe41c3f018"},
-    {file = "SQLAlchemy-2.0.25-cp311-cp311-win32.whl", hash = "sha256:e607cdd99cbf9bb80391f54446b86e16eea6ad309361942bf88318bcd452363c"},
-    {file = "SQLAlchemy-2.0.25-cp311-cp311-win_amd64.whl", hash = "sha256:7d505815ac340568fd03f719446a589162d55c52f08abd77ba8964fbb7eb5b5f"},
-    {file = "SQLAlchemy-2.0.25-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:0dacf67aee53b16f365c589ce72e766efaabd2b145f9de7c917777b575e3659d"},
-    {file = "SQLAlchemy-2.0.25-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b801154027107461ee992ff4b5c09aa7cc6ec91ddfe50d02bca344918c3265c6"},
-    {file = "SQLAlchemy-2.0.25-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:59a21853f5daeb50412d459cfb13cb82c089ad4c04ec208cd14dddd99fc23b39"},
-    {file = "SQLAlchemy-2.0.25-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:29049e2c299b5ace92cbed0c1610a7a236f3baf4c6b66eb9547c01179f638ec5"},
-    {file = "SQLAlchemy-2.0.25-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b64b183d610b424a160b0d4d880995e935208fc043d0302dd29fee32d1ee3f95"},
-    {file = "SQLAlchemy-2.0.25-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4f7a7d7fcc675d3d85fbf3b3828ecd5990b8d61bd6de3f1b260080b3beccf215"},
-    {file = "SQLAlchemy-2.0.25-cp312-cp312-win32.whl", hash = "sha256:cf18ff7fc9941b8fc23437cc3e68ed4ebeff3599eec6ef5eebf305f3d2e9a7c2"},
-    {file = "SQLAlchemy-2.0.25-cp312-cp312-win_amd64.whl", hash = "sha256:91f7d9d1c4dd1f4f6e092874c128c11165eafcf7c963128f79e28f8445de82d5"},
-    {file = "SQLAlchemy-2.0.25-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:bb209a73b8307f8fe4fe46f6ad5979649be01607f11af1eb94aa9e8a3aaf77f0"},
-    {file = "SQLAlchemy-2.0.25-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:798f717ae7c806d67145f6ae94dc7c342d3222d3b9a311a784f371a4333212c7"},
-    {file = "SQLAlchemy-2.0.25-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5fdd402169aa00df3142149940b3bf9ce7dde075928c1886d9a1df63d4b8de62"},
-    {file = "SQLAlchemy-2.0.25-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:0d3cab3076af2e4aa5693f89622bef7fa770c6fec967143e4da7508b3dceb9b9"},
-    {file = "SQLAlchemy-2.0.25-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:74b080c897563f81062b74e44f5a72fa44c2b373741a9ade701d5f789a10ba23"},
-    {file = "SQLAlchemy-2.0.25-cp37-cp37m-win32.whl", hash = "sha256:87d91043ea0dc65ee583026cb18e1b458d8ec5fc0a93637126b5fc0bc3ea68c4"},
-    {file = "SQLAlchemy-2.0.25-cp37-cp37m-win_amd64.whl", hash = "sha256:75f99202324383d613ddd1f7455ac908dca9c2dd729ec8584c9541dd41822a2c"},
-    {file = "SQLAlchemy-2.0.25-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:420362338681eec03f53467804541a854617faed7272fe71a1bfdb07336a381e"},
-    {file = "SQLAlchemy-2.0.25-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7c88f0c7dcc5f99bdb34b4fd9b69b93c89f893f454f40219fe923a3a2fd11625"},
-    {file = "SQLAlchemy-2.0.25-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3be4987e3ee9d9a380b66393b77a4cd6d742480c951a1c56a23c335caca4ce3"},
-    {file = "SQLAlchemy-2.0.25-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2a159111a0f58fb034c93eeba211b4141137ec4b0a6e75789ab7a3ef3c7e7e3"},
-    {file = "SQLAlchemy-2.0.25-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:8b8cb63d3ea63b29074dcd29da4dc6a97ad1349151f2d2949495418fd6e48db9"},
-    {file = "SQLAlchemy-2.0.25-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:736ea78cd06de6c21ecba7416499e7236a22374561493b456a1f7ffbe3f6cdb4"},
-    {file = "SQLAlchemy-2.0.25-cp38-cp38-win32.whl", hash = "sha256:10331f129982a19df4284ceac6fe87353ca3ca6b4ca77ff7d697209ae0a5915e"},
-    {file = "SQLAlchemy-2.0.25-cp38-cp38-win_amd64.whl", hash = "sha256:c55731c116806836a5d678a70c84cb13f2cedba920212ba7dcad53260997666d"},
-    {file = "SQLAlchemy-2.0.25-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:605b6b059f4b57b277f75ace81cc5bc6335efcbcc4ccb9066695e515dbdb3900"},
-    {file = "SQLAlchemy-2.0.25-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:665f0a3954635b5b777a55111ababf44b4fc12b1f3ba0a435b602b6387ffd7cf"},
-    {file = "SQLAlchemy-2.0.25-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ecf6d4cda1f9f6cb0b45803a01ea7f034e2f1aed9475e883410812d9f9e3cfcf"},
-    {file = "SQLAlchemy-2.0.25-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c51db269513917394faec5e5c00d6f83829742ba62e2ac4fa5c98d58be91662f"},
-    {file = "SQLAlchemy-2.0.25-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:790f533fa5c8901a62b6fef5811d48980adeb2f51f1290ade8b5e7ba990ba3de"},
-    {file = "SQLAlchemy-2.0.25-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:1b1180cda6df7af84fe72e4530f192231b1f29a7496951db4ff38dac1687202d"},
-    {file = "SQLAlchemy-2.0.25-cp39-cp39-win32.whl", hash = "sha256:555651adbb503ac7f4cb35834c5e4ae0819aab2cd24857a123370764dc7d7e24"},
-    {file = "SQLAlchemy-2.0.25-cp39-cp39-win_amd64.whl", hash = "sha256:dc55990143cbd853a5d038c05e79284baedf3e299661389654551bd02a6a68d7"},
-    {file = "SQLAlchemy-2.0.25-py3-none-any.whl", hash = "sha256:a86b4240e67d4753dc3092d9511886795b3c2852abe599cffe108952f7af7ac3"},
-    {file = "SQLAlchemy-2.0.25.tar.gz", hash = "sha256:a2c69a7664fb2d54b8682dd774c3b54f67f84fa123cf84dda2a5f40dcaa04e08"},
+    {file = "SQLAlchemy-2.0.27-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d04e579e911562f1055d26dab1868d3e0bb905db3bccf664ee8ad109f035618a"},
+    {file = "SQLAlchemy-2.0.27-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fa67d821c1fd268a5a87922ef4940442513b4e6c377553506b9db3b83beebbd8"},
+    {file = "SQLAlchemy-2.0.27-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c7a596d0be71b7baa037f4ac10d5e057d276f65a9a611c46970f012752ebf2d"},
+    {file = "SQLAlchemy-2.0.27-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:954d9735ee9c3fa74874c830d089a815b7b48df6f6b6e357a74130e478dbd951"},
+    {file = "SQLAlchemy-2.0.27-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:5cd20f58c29bbf2680039ff9f569fa6d21453fbd2fa84dbdb4092f006424c2e6"},
+    {file = "SQLAlchemy-2.0.27-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:03f448ffb731b48323bda68bcc93152f751436ad6037f18a42b7e16af9e91c07"},
+    {file = "SQLAlchemy-2.0.27-cp310-cp310-win32.whl", hash = "sha256:d997c5938a08b5e172c30583ba6b8aad657ed9901fc24caf3a7152eeccb2f1b4"},
+    {file = "SQLAlchemy-2.0.27-cp310-cp310-win_amd64.whl", hash = "sha256:eb15ef40b833f5b2f19eeae65d65e191f039e71790dd565c2af2a3783f72262f"},
+    {file = "SQLAlchemy-2.0.27-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6c5bad7c60a392850d2f0fee8f355953abaec878c483dd7c3836e0089f046bf6"},
+    {file = "SQLAlchemy-2.0.27-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3012ab65ea42de1be81fff5fb28d6db893ef978950afc8130ba707179b4284a"},
+    {file = "SQLAlchemy-2.0.27-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dbcd77c4d94b23e0753c5ed8deba8c69f331d4fd83f68bfc9db58bc8983f49cd"},
+    {file = "SQLAlchemy-2.0.27-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d177b7e82f6dd5e1aebd24d9c3297c70ce09cd1d5d37b43e53f39514379c029c"},
+    {file = "SQLAlchemy-2.0.27-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:680b9a36029b30cf063698755d277885d4a0eab70a2c7c6e71aab601323cba45"},
+    {file = "SQLAlchemy-2.0.27-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:1306102f6d9e625cebaca3d4c9c8f10588735ef877f0360b5cdb4fdfd3fd7131"},
+    {file = "SQLAlchemy-2.0.27-cp311-cp311-win32.whl", hash = "sha256:5b78aa9f4f68212248aaf8943d84c0ff0f74efc65a661c2fc68b82d498311fd5"},
+    {file = "SQLAlchemy-2.0.27-cp311-cp311-win_amd64.whl", hash = "sha256:15e19a84b84528f52a68143439d0c7a3a69befcd4f50b8ef9b7b69d2628ae7c4"},
+    {file = "SQLAlchemy-2.0.27-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:0de1263aac858f288a80b2071990f02082c51d88335a1db0d589237a3435fe71"},
+    {file = "SQLAlchemy-2.0.27-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce850db091bf7d2a1f2fdb615220b968aeff3849007b1204bf6e3e50a57b3d32"},
+    {file = "SQLAlchemy-2.0.27-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8dfc936870507da96aebb43e664ae3a71a7b96278382bcfe84d277b88e379b18"},
+    {file = "SQLAlchemy-2.0.27-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c4fbe6a766301f2e8a4519f4500fe74ef0a8509a59e07a4085458f26228cd7cc"},
+    {file = "SQLAlchemy-2.0.27-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:4535c49d961fe9a77392e3a630a626af5baa967172d42732b7a43496c8b28876"},
+    {file = "SQLAlchemy-2.0.27-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0fb3bffc0ced37e5aa4ac2416f56d6d858f46d4da70c09bb731a246e70bff4d5"},
+    {file = "SQLAlchemy-2.0.27-cp312-cp312-win32.whl", hash = "sha256:7f470327d06400a0aa7926b375b8e8c3c31d335e0884f509fe272b3c700a7254"},
+    {file = "SQLAlchemy-2.0.27-cp312-cp312-win_amd64.whl", hash = "sha256:f9374e270e2553653d710ece397df67db9d19c60d2647bcd35bfc616f1622dcd"},
+    {file = "SQLAlchemy-2.0.27-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e97cf143d74a7a5a0f143aa34039b4fecf11343eed66538610debc438685db4a"},
+    {file = "SQLAlchemy-2.0.27-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7b5a3e2120982b8b6bd1d5d99e3025339f7fb8b8267551c679afb39e9c7c7f1"},
+    {file = "SQLAlchemy-2.0.27-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e36aa62b765cf9f43a003233a8c2d7ffdeb55bc62eaa0a0380475b228663a38f"},
+    {file = "SQLAlchemy-2.0.27-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:5ada0438f5b74c3952d916c199367c29ee4d6858edff18eab783b3978d0db16d"},
+    {file = "SQLAlchemy-2.0.27-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:b1d9d1bfd96eef3c3faedb73f486c89e44e64e40e5bfec304ee163de01cf996f"},
+    {file = "SQLAlchemy-2.0.27-cp37-cp37m-win32.whl", hash = "sha256:ca891af9f3289d24a490a5fde664ea04fe2f4984cd97e26de7442a4251bd4b7c"},
+    {file = "SQLAlchemy-2.0.27-cp37-cp37m-win_amd64.whl", hash = "sha256:fd8aafda7cdff03b905d4426b714601c0978725a19efc39f5f207b86d188ba01"},
+    {file = "SQLAlchemy-2.0.27-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ec1f5a328464daf7a1e4e385e4f5652dd9b1d12405075ccba1df842f7774b4fc"},
+    {file = "SQLAlchemy-2.0.27-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:ad862295ad3f644e3c2c0d8b10a988e1600d3123ecb48702d2c0f26771f1c396"},
+    {file = "SQLAlchemy-2.0.27-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48217be1de7d29a5600b5c513f3f7664b21d32e596d69582be0a94e36b8309cb"},
+    {file = "SQLAlchemy-2.0.27-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e56afce6431450442f3ab5973156289bd5ec33dd618941283847c9fd5ff06bf"},
+    {file = "SQLAlchemy-2.0.27-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:611068511b5531304137bcd7fe8117c985d1b828eb86043bd944cebb7fae3910"},
+    {file = "SQLAlchemy-2.0.27-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b86abba762ecfeea359112b2bb4490802b340850bbee1948f785141a5e020de8"},
+    {file = "SQLAlchemy-2.0.27-cp38-cp38-win32.whl", hash = "sha256:30d81cc1192dc693d49d5671cd40cdec596b885b0ce3b72f323888ab1c3863d5"},
+    {file = "SQLAlchemy-2.0.27-cp38-cp38-win_amd64.whl", hash = "sha256:120af1e49d614d2525ac247f6123841589b029c318b9afbfc9e2b70e22e1827d"},
+    {file = "SQLAlchemy-2.0.27-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d07ee7793f2aeb9b80ec8ceb96bc8cc08a2aec8a1b152da1955d64e4825fcbac"},
+    {file = "SQLAlchemy-2.0.27-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:cb0845e934647232b6ff5150df37ceffd0b67b754b9fdbb095233deebcddbd4a"},
+    {file = "SQLAlchemy-2.0.27-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fc19ae2e07a067663dd24fca55f8ed06a288384f0e6e3910420bf4b1270cc51"},
+    {file = "SQLAlchemy-2.0.27-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b90053be91973a6fb6020a6e44382c97739736a5a9d74e08cc29b196639eb979"},
+    {file = "SQLAlchemy-2.0.27-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:2f5c9dfb0b9ab5e3a8a00249534bdd838d943ec4cfb9abe176a6c33408430230"},
+    {file = "SQLAlchemy-2.0.27-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:33e8bde8fff203de50399b9039c4e14e42d4d227759155c21f8da4a47fc8053c"},
+    {file = "SQLAlchemy-2.0.27-cp39-cp39-win32.whl", hash = "sha256:d873c21b356bfaf1589b89090a4011e6532582b3a8ea568a00e0c3aab09399dd"},
+    {file = "SQLAlchemy-2.0.27-cp39-cp39-win_amd64.whl", hash = "sha256:ff2f1b7c963961d41403b650842dc2039175b906ab2093635d8319bef0b7d620"},
+    {file = "SQLAlchemy-2.0.27-py3-none-any.whl", hash = "sha256:1ab4e0448018d01b142c916cc7119ca573803a4745cfe341b8f95657812700ac"},
+    {file = "SQLAlchemy-2.0.27.tar.gz", hash = "sha256:86a6ed69a71fe6b88bf9331594fa390a2adda4a49b5c06f98e47bf0d392534f8"},
 ]
 
 [package.dependencies]
@@ -1657,13 +1668,13 @@ typing-extensions = ">=3.7.4"
 
 [[package]]
 name = "tzdata"
-version = "2023.4"
+version = "2024.1"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
 files = [
-    {file = "tzdata-2023.4-py2.py3-none-any.whl", hash = "sha256:aa3ace4329eeacda5b7beb7ea08ece826c28d761cda36e747cfbf97996d39bf3"},
-    {file = "tzdata-2023.4.tar.gz", hash = "sha256:dd54c94f294765522c77399649b4fefd95522479a664a0cec87f41bebc6148c9"},
+    {file = "tzdata-2024.1-py2.py3-none-any.whl", hash = "sha256:9068bc196136463f5245e51efda838afa15aaeca9903f49050dfa2679db4d252"},
+    {file = "tzdata-2024.1.tar.gz", hash = "sha256:2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd"},
 ]
 
 [[package]]
@@ -1783,4 +1794,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "bed1be5427eccd40de85f79c3a7e065e06d3dbff88af88ac511ab7c91a25094b"
+content-hash = "57819a81ed7c6702dcb1388f906bc53335f1b26fa2ae509b1958161708314b6f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ regtech-data-validator = {git = "https://github.com/cfpb/regtech-data-validator.
 python-multipart = "^0.0.6"
 boto3 = "^1.33.12"
 alembic = "^1.12.0"
+async-lru = "^2.0.4"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.3"

--- a/src/entities/models/dto.py
+++ b/src/entities/models/dto.py
@@ -30,7 +30,7 @@ class FilingTaskStateDTO(BaseModel):
     task: FilingTaskDTO
     user: str | None = None
     state: FilingTaskState
-    change_timestamp: datetime
+    change_timestamp: datetime | None = None
 
 
 class FilingDTO(BaseModel):

--- a/src/entities/repos/submission_repo.py
+++ b/src/entities/repos/submission_repo.py
@@ -123,22 +123,22 @@ async def upsert_filing(session: AsyncSession, filing: FilingDTO) -> FilingDAO:
     return await upsert_helper(session, filing, FilingDAO)
 
 
-async def upsert_helper(session: AsyncSession, original_data: Any, type: T) -> T:
+async def upsert_helper(session: AsyncSession, original_data: Any, table_obj: T) -> T:
     copy_data = original_data.__dict__.copy()
     # this is only for if a DAO is passed in
     # Should be DTOs, but hey, it's python
     if copy_data["id"] is not None and "_sa_instance_state" in copy_data:
         del copy_data["_sa_instance_state"]
-    new_dao = type(**copy_data)
+    new_dao = table_obj(**copy_data)
     new_dao = await session.merge(new_dao)
     await session.commit()
     return new_dao
 
 
-async def query_helper(session: AsyncSession, type: T, column_name: str = None, value: Any = None) -> List[T]:
-    stmt = select(type)
+async def query_helper(session: AsyncSession, table_obj: T, column_name: str = None, value: Any = None) -> List[T]:
+    stmt = select(table_obj)
     if column_name and value:
-        stmt = stmt.filter(getattr(type, column_name) == value)
+        stmt = stmt.filter(getattr(table_obj, column_name) == value)
     return (await session.scalars(stmt)).all()
 
 

--- a/src/entities/repos/submission_repo.py
+++ b/src/entities/repos/submission_repo.py
@@ -4,6 +4,9 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import Any, List, TypeVar
 from entities.engine import get_session
+from regtech_api_commons.models.auth import AuthenticatedUser
+
+from copy import deepcopy
 
 from entities.models import (
     SubmissionDAO,
@@ -14,6 +17,8 @@ from entities.models import (
     FilingDTO,
     FilingDAO,
     FilingTaskDAO,
+    FilingTaskStateDAO,
+    FilingTaskState,
 )
 
 logger = logging.getLogger(__name__)
@@ -21,39 +26,67 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
+class NoFilingPeriodException(Exception):
+    pass
+
+
 async def get_submissions(session: AsyncSession, filing_id: int = None) -> List[SubmissionDAO]:
-    async with session.begin():
-        stmt = select(SubmissionDAO)
-        if filing_id:
-            stmt = stmt.filter(SubmissionDAO.filing == filing_id)
-        results = await session.scalars(stmt)
-        return results.all()
+    return await query_helper(session, SubmissionDAO, "filing", filing_id)
 
 
 async def get_filing_periods(session: AsyncSession) -> List[FilingPeriodDAO]:
-    async with session.begin():
-        stmt = select(FilingPeriodDAO)
-        results = await session.scalars(stmt)
-        return results.all()
+    return await query_helper(session, FilingPeriodDAO)
 
 
 async def get_submission(session: AsyncSession, submission_id: int) -> SubmissionDAO:
-    return await query_helper(session, submission_id, SubmissionDAO)
+    result = await query_helper(session, SubmissionDAO, "id", submission_id)
+    return result[0] if result else None
 
 
 async def get_filing(session: AsyncSession, filing_id: int) -> FilingDAO:
-    return await query_helper(session, filing_id, FilingDAO)
+    result = await query_helper(session, FilingDAO, "id", filing_id)
+    result = deepcopy(result)
+    if result:
+        await populate_missing_tasks(session, result)
+    return result[0] if result else None
+
+
+async def get_period_filings_for_user(
+    session: AsyncSession, user: AuthenticatedUser, period_name: str
+) -> List[FilingDAO]:
+    filing_period = await query_helper(session, FilingPeriodDAO, "name", period_name)
+    if filing_period:
+        filings = await query_helper(session, FilingDAO, "filing_period", filing_period[0].id)
+        filings = [f for f in filings if f.lei in user.institutions]
+        filing_leis = [f.lei for f in filings]
+        missing_filing_leis = [lei for lei in user.institutions if lei not in filing_leis]
+        if missing_filing_leis:
+            for lei in missing_filing_leis:
+                filing_dao = await upsert_filing(
+                    session,
+                    FilingDTO(
+                        lei=lei,
+                        tasks=[],
+                        filing_period=filing_period[0].id,
+                        institution_snapshot_id="v1",  # TODO: add function to get this from user-fi-api
+                    ),
+                )
+                filings.append(filing_dao)
+        filings = deepcopy(filings)
+        await populate_missing_tasks(session, filings)
+
+        return filings
+    else:
+        raise NoFilingPeriodException(f"There is no Filing Period with name {period_name} defined in the database.")
 
 
 async def get_filing_period(session: AsyncSession, filing_period_id: int) -> FilingPeriodDAO:
-    return await query_helper(session, filing_period_id, FilingPeriodDAO)
+    result = await query_helper(session, FilingPeriodDAO, "id", filing_period_id)
+    return result[0] if result else None
 
 
 async def get_filing_tasks(session: AsyncSession) -> List[FilingTaskDAO]:
-    async with session.begin():
-        stmt = select(FilingTaskDAO)
-        results = await session.scalars(stmt)
-        return results.all()
+    return await query_helper(session, FilingTaskDAO)
 
 
 async def add_submission(session: AsyncSession, submission: SubmissionDTO) -> SubmissionDAO:
@@ -91,19 +124,29 @@ async def upsert_filing(session: AsyncSession, filing: FilingDTO) -> FilingDAO:
 
 
 async def upsert_helper(session: AsyncSession, original_data: Any, type: T) -> T:
-    async with session.begin():
-        copy_data = original_data.__dict__.copy()
-        # this is only for if a DAO is passed in
-        # Should be DTOs, but hey, it's python
-        if copy_data["id"] is not None and "_sa_instance_state" in copy_data:
-            del copy_data["_sa_instance_state"]
-        new_dao = type(**copy_data)
-        new_dao = await session.merge(new_dao)
-        await session.commit()
-        return new_dao
+    copy_data = original_data.__dict__.copy()
+    # this is only for if a DAO is passed in
+    # Should be DTOs, but hey, it's python
+    if copy_data["id"] is not None and "_sa_instance_state" in copy_data:
+        del copy_data["_sa_instance_state"]
+    new_dao = type(**copy_data)
+    new_dao = await session.merge(new_dao)
+    await session.commit()
+    return new_dao
 
 
-async def query_helper(session: AsyncSession, id: int, type: T) -> T:
-    async with session.begin():
-        stmt = select(type).filter(type.id == id)
-        return await session.scalar(stmt)
+async def query_helper(session: AsyncSession, type: T, column_name: str = None, value: Any = None) -> List[T]:
+    stmt = select(type)
+    if column_name and value:
+        stmt = stmt.filter(getattr(type, column_name) == value)
+    return (await session.scalars(stmt)).all()
+
+
+async def populate_missing_tasks(session: AsyncSession, filings: List[FilingDAO]):
+    filing_tasks = await query_helper(session, FilingTaskDAO)
+    for f in filings:
+        missing_tasks = [t for t in filing_tasks if t not in f.tasks]
+        for mt in missing_tasks:
+            f.tasks.append(
+                FilingTaskStateDAO(filing=f.id, task_name=mt.name, state=FilingTaskState.NOT_STARTED, user="")
+            )

--- a/src/routers/filing.py
+++ b/src/routers/filing.py
@@ -1,11 +1,11 @@
 from http import HTTPStatus
-from fastapi import Depends, Request, UploadFile, BackgroundTasks
+from fastapi import Depends, Request, UploadFile, BackgroundTasks, HTTPException
 from regtech_api_commons.api import Router
 from services import submission_processor
 from typing import Annotated, List
 
 from entities.engine import get_session
-from entities.models import FilingPeriodDTO, SubmissionDTO
+from entities.models import FilingPeriodDTO, SubmissionDTO, FilingDTO
 from entities.repos import submission_repo as repo
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -21,6 +21,15 @@ router = Router(dependencies=[Depends(set_db)])
 @router.get("/periods", response_model=List[FilingPeriodDTO])
 async def get_filing_periods(request: Request):
     return await repo.get_filing_periods(request.state.db_session)
+
+
+# This has to come after the /periods endpoint
+@router.get("/{period_name}", response_model=List[FilingDTO])
+async def get_filings(request: Request, period_name: str):
+    try:
+        return await repo.get_period_filings_for_user(request.state.db_session, period_name)
+    except repo.NoFilingPeriodException as nfpe:
+        raise HTTPException(status_code=500, detail=str(nfpe))
 
 
 @router.post("/{lei}/submissions/{submission_id}", status_code=HTTPStatus.ACCEPTED)

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -5,7 +5,8 @@ from fastapi import FastAPI
 from pytest_mock import MockerFixture
 from unittest.mock import Mock
 
-from entities.models import FilingPeriodDAO, FilingType
+from entities.models import FilingPeriodDAO, FilingType, FilingDAO, FilingTaskStateDAO, FilingTaskState, FilingTaskDAO
+from entities.repos import submission_repo as repo
 
 
 @pytest.fixture
@@ -27,4 +28,44 @@ def get_filing_period_mock(mocker: MockerFixture) -> Mock:
             filing_type=FilingType.ANNUAL,
         )
     ]
+    return mock
+
+
+@pytest.fixture
+def get_filings_mock(mocker: MockerFixture) -> Mock:
+    mock = mocker.patch("entities.repos.submission_repo.get_period_filings_for_user")
+    mock.return_value = [
+        FilingDAO(
+            id=1,
+            lei="12345678",
+            tasks=[
+                FilingTaskStateDAO(
+                    filing=1,
+                    task=FilingTaskDAO(name="Task-1", task_order=1),
+                    state=FilingTaskState.NOT_STARTED,
+                    user="",
+                ),
+                FilingTaskStateDAO(
+                    filing=1,
+                    task=FilingTaskDAO(name="Task-2", task_order=2),
+                    state=FilingTaskState.NOT_STARTED,
+                    user="",
+                ),
+            ],
+            filing_period=1,
+            institution_snapshot_id="v1",
+            contact_info="test@cfpb.gov",
+        )
+    ]
+    return mock
+
+
+@pytest.fixture
+def get_filings_error_mock(mocker: MockerFixture) -> Mock:
+    mock = mocker.patch(
+        "entities.repos.submission_repo.get_period_filings_for_user",
+        side_effect=repo.NoFilingPeriodException(
+            "There is no Filing Period with name FilingPeriod2025 defined in the database."
+        ),
+    )
     return mock

--- a/tests/api/routers/test_filing_api.py
+++ b/tests/api/routers/test_filing_api.py
@@ -15,6 +15,22 @@ class TestFilingApi:
         assert len(res.json()) == 1
         assert res.json()[0]["name"] == "FilingPeriod2024"
 
+    def test_get_filings(self, app_fixture: FastAPI, get_filings_mock: Mock):
+        client = TestClient(app_fixture)
+        res = client.get("/v1/filing/FilingPeriod2024")
+        get_filings_mock.assert_called_with(ANY, "FilingPeriod2024")
+        assert res.status_code == 200
+        assert len(res.json()) == 1
+        assert res.json()[0]["lei"] == "12345678"
+
+    def test_get_filings_with_error(self, app_fixture: FastAPI, get_filings_error_mock: Mock):
+        client = TestClient(app_fixture)
+        response = client.get("/v1/filing/FilingPeriod2025")
+        assert response.status_code == 500
+        assert response.json() == {
+            "detail": "There is no Filing Period with name FilingPeriod2025 defined in the database."
+        }
+
     async def test_get_submissions(self, mocker: MockerFixture, app_fixture: FastAPI):
         mock = mocker.patch("entities.repos.submission_repo.get_submissions")
         mock.return_value = [

--- a/tests/entities/repos/test_submission_repo.py
+++ b/tests/entities/repos/test_submission_repo.py
@@ -23,6 +23,8 @@ from pytest_mock import MockerFixture
 
 from entities.engine import engine as entities_engine
 
+from regtech_api_commons.models.auth import AuthenticatedUser
+
 
 class TestSubmissionRepo:
     @pytest.fixture(scope="function", autouse=True)
@@ -149,10 +151,40 @@ class TestSubmissionRepo:
         res = await repo.get_filing(query_session, filing_id=1)
         assert res.id == 1
         assert res.lei == "1234567890"
+        assert len(res.tasks) == 2
+        assert FilingTaskState.NOT_STARTED in set([t.state for t in res.tasks])
 
         res = await repo.get_filing(query_session, filing_id=2)
         assert res.id == 2
         assert res.lei == "ABCDEFGHIJ"
+        assert len(res.tasks) == 2
+        assert FilingTaskState.NOT_STARTED in set([t.state for t in res.tasks])
+
+    async def test_get_period_filings_for_user(self, query_session: AsyncSession, mocker: MockerFixture):
+        # Verify a user with no filing for an LEI gets one
+        user = AuthenticatedUser.from_claim({"institutions": ["ZYXWVUTSRQP"]})
+        results = await repo.get_period_filings_for_user(query_session, user, period_name="FilingPeriod2024")
+        assert len(results) == 1
+        assert results[0].id == 3
+        assert results[0].lei == "ZYXWVUTSRQP"
+        assert len(results[0].tasks) == 2
+
+        # Verify a user with two LEIs and one started filing gets two filings, one for the started
+        # and one newly created
+        user = AuthenticatedUser.from_claim({"institutions": ["1234567890", "0987654321"]})
+        results = await repo.get_period_filings_for_user(query_session, user, period_name="FilingPeriod2024")
+        assert len(results) == 2
+        assert results[0].id == 1
+        assert results[0].lei == "1234567890"
+        assert results[1].id == 4
+        assert results[1].lei == "0987654321"
+        assert len(results[0].tasks) == 2
+        assert len(results[1].tasks) == 2
+
+        try:
+            await repo.get_period_filings_for_user(query_session, user, period_name="FilingPeriod2025")
+        except repo.NoFilingPeriodException as nfpe:
+            assert str(nfpe) == "There is no Filing Period with name FilingPeriod2025 defined in the database."
 
     async def test_get_submission(self, query_session: AsyncSession):
         res = await repo.get_submission(query_session, submission_id=1)

--- a/tests/entities/repos/test_submission_repo.py
+++ b/tests/entities/repos/test_submission_repo.py
@@ -161,25 +161,16 @@ class TestSubmissionRepo:
         assert FilingTaskState.NOT_STARTED in set([t.state for t in res.tasks])
 
     async def test_get_period_filings_for_user(self, query_session: AsyncSession, mocker: MockerFixture):
-        # Verify a user with no filing for an LEI gets one
         user = AuthenticatedUser.from_claim({"institutions": ["ZYXWVUTSRQP"]})
         results = await repo.get_period_filings_for_user(query_session, user, period_name="FilingPeriod2024")
-        assert len(results) == 1
-        assert results[0].id == 3
-        assert results[0].lei == "ZYXWVUTSRQP"
-        assert len(results[0].tasks) == 2
+        assert len(results) == 0
 
-        # Verify a user with two LEIs and one started filing gets two filings, one for the started
-        # and one newly created
         user = AuthenticatedUser.from_claim({"institutions": ["1234567890", "0987654321"]})
         results = await repo.get_period_filings_for_user(query_session, user, period_name="FilingPeriod2024")
-        assert len(results) == 2
+        assert len(results) == 1
         assert results[0].id == 1
         assert results[0].lei == "1234567890"
-        assert results[1].id == 4
-        assert results[1].lei == "0987654321"
         assert len(results[0].tasks) == 2
-        assert len(results[1].tasks) == 2
 
         try:
             await repo.get_period_filings_for_user(query_session, user, period_name="FilingPeriod2025")


### PR DESCRIPTION
Closes #53 

- Added /{period_name} endpoint (/v1/filing/{period_name} 
- Added get_period_filings_for_user in submission_repo which will pull out LEIs from AuthUser object and compare to filings for period, getting which ever match the user's LEI list and creating new filing object(s) for LEIs without an existing filing
- Adds a 500 if the passed in filing period name doesn't exist in the db
- Set the change_timestamp in FilingTaskState to be optional for the cases where the task hasn't been started (no changes/updates yet)
- Updated the query_helper function to be more generic, can pass in any DAO type and any field name/value for filtering.  Only allows for one field filter, should look into making this *field_name or something to allow for multiple filters
- Added pytests for all that.