### PR TITLE
Updated get_filing endpoint to return 204 if no filing dao is found

### DIFF
--- a/src/routers/filing.py
+++ b/src/routers/filing.py
@@ -30,7 +30,10 @@ async def get_filing_periods(request: Request):
 @router.get("/institutions/{lei}/filings/{period_name}", response_model=FilingDTO)
 @requires("authenticated")
 async def get_filing(request: Request, lei: str, period_name: str):
-    return await repo.get_filing(request.state.db_session, lei, period_name)
+    res = await repo.get_filing(request.state.db_session, lei, period_name)
+    if not res:
+        return JSONResponse(status_code=status.HTTP_204_NO_CONTENT, content=None)
+    return res
 
 
 @router.post("/institutions/{lei}/filings/{period_name}", response_model=FilingDTO)

--- a/tests/api/routers/test_filing_api.py
+++ b/tests/api/routers/test_filing_api.py
@@ -41,6 +41,10 @@ class TestFilingApi:
         assert res.json()["lei"] == "1234567890"
         assert res.json()["filing_period"] == "2024"
 
+        get_filing_mock.return_value = None
+        res = client.get("/v1/filing/institutions/1234567890/filings/2024/")
+        assert res.status_code == 204
+
     def test_unauthed_post_filing(self, app_fixture: FastAPI, post_filing_mock: Mock):
         client = TestClient(app_fixture)
         res = client.post("/v1/filing/institutions/ZXWVUTSRQP/filings/2024/")


### PR DESCRIPTION
Closes #81 

- Updated get_filing endpoint to check repo result and if None, return a 204 NO_CONTENT response
- Updated pytest