### PR TITLE
Added 409 status for existing Filing on POST

### DIFF
--- a/src/routers/filing.py
+++ b/src/routers/filing.py
@@ -9,6 +9,7 @@ from entities.engine import get_session
 from entities.models import FilingPeriodDTO, SubmissionDTO, FilingDTO, UpdateValueDTO, StateUpdateDTO
 from entities.repos import submission_repo as repo
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from starlette.authentication import requires
@@ -38,17 +39,14 @@ async def get_filing(request: Request, lei: str, period_name: str):
 
 @router.post("/institutions/{lei}/filings/{period_name}", response_model=FilingDTO)
 @requires("authenticated")
-async def post_filing(request: Request, lei: str, period_name: str, filing_obj: FilingDTO = None):
-    if filing_obj:
-        return await repo.upsert_filing(request.state.db_session, filing_obj)
-    else:
-        result = await repo.get_filing(request.state.db_session, lei, period_name)
-        if result:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=f"Filing already exists for Filing Period {period_name} and LEI {lei}",
-            )
+async def post_filing(request: Request, lei: str, period_name: str):
+    try:
         return await repo.create_new_filing(request.state.db_session, lei, period_name)
+    except IntegrityError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Filing already exists for Filing Period {period_name} and LEI {lei}",
+        )
 
 
 @router.post("/{lei}/submissions/{submission_id}", status_code=HTTPStatus.ACCEPTED)

--- a/src/routers/filing.py
+++ b/src/routers/filing.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from fastapi import Depends, Request, UploadFile, BackgroundTasks, status
+from fastapi import Depends, Request, UploadFile, BackgroundTasks, status, HTTPException
 from fastapi.responses import JSONResponse
 from regtech_api_commons.api import Router
 from services import submission_processor
@@ -42,6 +42,12 @@ async def post_filing(request: Request, lei: str, period_name: str, filing_obj: 
     if filing_obj:
         return await repo.upsert_filing(request.state.db_session, filing_obj)
     else:
+        result = await repo.get_filing(request.state.db_session, lei, period_name)
+        if result:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Filing already exists for Filing Period {period_name} and LEI {lei}",
+            )
         return await repo.create_new_filing(request.state.db_session, lei, period_name)
 
 

--- a/tests/api/routers/test_filing_api.py
+++ b/tests/api/routers/test_filing_api.py
@@ -54,8 +54,15 @@ class TestFilingApi:
         res = client.post("/v1/filing/institutions/ZXWVUTSRQP/filings/2024/")
         assert res.status_code == 403
 
-    def test_post_filing(self, app_fixture: FastAPI, post_filing_mock: Mock, authed_user_mock: Mock):
+    def test_post_filing(
+        self, app_fixture: FastAPI, get_filing_mock: Mock, post_filing_mock: Mock, authed_user_mock: Mock
+    ):
         client = TestClient(app_fixture)
+        res = client.post("/v1/filing/institutions/1234567890/filings/2024/")
+        assert res.status_code == 409
+        assert res.json()["detail"] == "Filing already exists for Filing Period 2024 and LEI 1234567890"
+
+        get_filing_mock.return_value = None
         res = client.post("/v1/filing/institutions/ZXWVUTSRQP/filings/2024/")
         post_filing_mock.assert_called_with(ANY, "ZXWVUTSRQP", "2024")
         assert res.status_code == 200

--- a/tests/api/routers/test_filing_api.py
+++ b/tests/api/routers/test_filing_api.py
@@ -57,7 +57,7 @@ class TestFilingApi:
         assert res.status_code == 403
 
     def test_post_filing(
-        self, app_fixture: FastAPI, get_filing_mock: Mock, post_filing_mock: Mock, authed_user_mock: Mock
+        self, app_fixture: FastAPI, post_filing_mock: Mock, authed_user_mock: Mock
     ):
         client = TestClient(app_fixture)
         post_filing_mock.side_effect = IntegrityError(None, None, None)

--- a/tests/api/routers/test_filing_api.py
+++ b/tests/api/routers/test_filing_api.py
@@ -14,6 +14,8 @@ from entities.models import SubmissionDAO, SubmissionState, FilingTaskState
 
 from services import lei_verifier
 
+from sqlalchemy.exc import IntegrityError
+
 
 class TestFilingApi:
     def test_unauthed_get_periods(
@@ -49,7 +51,7 @@ class TestFilingApi:
         res = client.get("/v1/filing/institutions/1234567890/filings/2024/")
         assert res.status_code == 204
 
-    def test_unauthed_post_filing(self, app_fixture: FastAPI, post_filing_mock: Mock):
+    def test_unauthed_post_filing(self, app_fixture: FastAPI):
         client = TestClient(app_fixture)
         res = client.post("/v1/filing/institutions/ZXWVUTSRQP/filings/2024/")
         assert res.status_code == 403
@@ -58,11 +60,12 @@ class TestFilingApi:
         self, app_fixture: FastAPI, get_filing_mock: Mock, post_filing_mock: Mock, authed_user_mock: Mock
     ):
         client = TestClient(app_fixture)
+        post_filing_mock.side_effect = IntegrityError(None, None, None)
         res = client.post("/v1/filing/institutions/1234567890/filings/2024/")
         assert res.status_code == 409
         assert res.json()["detail"] == "Filing already exists for Filing Period 2024 and LEI 1234567890"
 
-        get_filing_mock.return_value = None
+        post_filing_mock.side_effect = None
         res = client.post("/v1/filing/institutions/ZXWVUTSRQP/filings/2024/")
         post_filing_mock.assert_called_with(ANY, "ZXWVUTSRQP", "2024")
         assert res.status_code == 200

--- a/tests/api/routers/test_filing_api.py
+++ b/tests/api/routers/test_filing_api.py
@@ -56,9 +56,7 @@ class TestFilingApi:
         res = client.post("/v1/filing/institutions/ZXWVUTSRQP/filings/2024/")
         assert res.status_code == 403
 
-    def test_post_filing(
-        self, app_fixture: FastAPI, post_filing_mock: Mock, authed_user_mock: Mock
-    ):
+    def test_post_filing(self, app_fixture: FastAPI, post_filing_mock: Mock, authed_user_mock: Mock):
         client = TestClient(app_fixture)
         post_filing_mock.side_effect = IntegrityError(None, None, None)
         res = client.post("/v1/filing/institutions/1234567890/filings/2024/")


### PR DESCRIPTION
Closes #82 

- On "empty" filing POST, check if the lei + period filing exists and if so, throw a 409 CONFLICT result with message
- Updated filing post pytest

Let in the check if a FilingDTO is passed in because it sounds like there may be a desire for the frontend to post the initial filing json.  However, this will require us making the FilingDTO id optional which may not be desired.  If it's determined the empty POST is fine, then we can remove the check for a body to the POST in another story.
