### PR TITLE
Changed patch fields to put institution_snapshot_id endpoint

### DIFF
--- a/src/entities/models/__init__.py
+++ b/src/entities/models/__init__.py
@@ -13,7 +13,7 @@ __all__ = [
     "FilingPeriodDTO",
     "FilingType",
     "FilingTaskState",
-    "UpdateValueDTO",
+    "SnapshotUpdateDTO",
     "StateUpdateDTO",
     "ContactInfoDAO",
     "ContactInfoDTO",
@@ -26,7 +26,7 @@ from .dto import (
     FilingPeriodDTO,
     FilingTaskProgressDTO,
     FilingTaskDTO,
-    UpdateValueDTO,
+    SnapshotUpdateDTO,
     StateUpdateDTO,
     ContactInfoDTO,
 )

--- a/src/entities/models/dto.py
+++ b/src/entities/models/dto.py
@@ -71,10 +71,10 @@ class FilingPeriodDTO(BaseModel):
     filing_type: FilingType
 
 
-class UpdateValueDTO(BaseModel):
+class SnapshotUpdateDTO(BaseModel):
     model_config = ConfigDict(from_attribute=True)
 
-    value: str | int | float | bool
+    institution_snapshot_id: str
 
 
 class StateUpdateDTO(BaseModel):

--- a/src/routers/filing.py
+++ b/src/routers/filing.py
@@ -6,7 +6,7 @@ from services import submission_processor
 from typing import Annotated, List
 
 from entities.engine import get_session
-from entities.models import FilingPeriodDTO, SubmissionDTO, FilingDTO, UpdateValueDTO, StateUpdateDTO, ContactInfoDTO
+from entities.models import FilingPeriodDTO, SubmissionDTO, FilingDTO, SnapshotUpdateDTO, StateUpdateDTO, ContactInfoDTO
 from entities.repos import submission_repo as repo
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -79,14 +79,13 @@ async def get_submission(request: Request, id: str):
     return JSONResponse(status_code=status.HTTP_204_NO_CONTENT, content=None)
 
 
-@router.patch("/institutions/{lei}/filings/{period_name}/fields/{field_name}", response_model=FilingDTO)
+@router.put("/institutions/{lei}/filings/{period_name}/institution_snapshot_id", response_model=FilingDTO)
 @requires("authenticated")
-async def patch_filing(request: Request, lei: str, period_name: str, field_name: str, update_value: UpdateValueDTO):
+async def patch_filing(request: Request, lei: str, period_name: str, update_value: SnapshotUpdateDTO):
     result = await repo.get_filing(request.state.db_session, lei, period_name)
     if result:
-        if getattr(result, field_name, None):
-            setattr(result, field_name, update_value.value)
-            return await repo.upsert_filing(request.state.db_session, result)
+        result.institution_snapshot_id = update_value.institution_snapshot_id
+        return await repo.upsert_filing(request.state.db_session, result)
     return JSONResponse(status_code=status.HTTP_204_NO_CONTENT, content=None)
 
 

--- a/src/routers/filing.py
+++ b/src/routers/filing.py
@@ -79,9 +79,9 @@ async def get_submission(request: Request, id: str):
     return JSONResponse(status_code=status.HTTP_204_NO_CONTENT, content=None)
 
 
-@router.put("/institutions/{lei}/filings/{period_name}/institution_snapshot_id", response_model=FilingDTO)
+@router.put("/institutions/{lei}/filings/{period_name}/institution-snapshot-id", response_model=FilingDTO)
 @requires("authenticated")
-async def patch_filing(request: Request, lei: str, period_name: str, update_value: SnapshotUpdateDTO):
+async def put_institution_snapshot(request: Request, lei: str, period_name: str, update_value: SnapshotUpdateDTO):
     result = await repo.get_filing(request.state.db_session, lei, period_name)
     if result:
         result.institution_snapshot_id = update_value.institution_snapshot_id

--- a/tests/api/routers/test_filing_api.py
+++ b/tests/api/routers/test_filing_api.py
@@ -181,7 +181,7 @@ class TestFilingApi:
         client = TestClient(app_fixture)
 
         res = client.put(
-            "/v1/filing/institutions/1234567890/filings/2025/institution_snapshot_id",
+            "/v1/filing/institutions/1234567890/filings/2025/institution-snapshot-id",
             json={"institution_snapshot_id": "v3"},
         )
         assert res.status_code == 403
@@ -201,7 +201,7 @@ class TestFilingApi:
         # no existing filing for endpoint
         get_filing_mock.return_value = None
         res = client.put(
-            "/v1/filing/institutions/1234567890/filings/2025/institution_snapshot_id",
+            "/v1/filing/institutions/1234567890/filings/2025/institution-snapshot-id",
             json={"institution_snapshot_id": "v3"},
         )
         assert res.status_code == 204
@@ -215,14 +215,14 @@ class TestFilingApi:
 
         # unallowed value data type
         res = client.put(
-            "/v1/filing/institutions/1234567890/filings/2025/institution_snapshot_id",
+            "/v1/filing/institutions/1234567890/filings/2025/institution-snapshot-id",
             json={"institution_snapshot_id": ["1", "2"]},
         )
         assert res.status_code == 422
 
         # good
         res = client.put(
-            "/v1/filing/institutions/1234567890/filings/2025/institution_snapshot_id",
+            "/v1/filing/institutions/1234567890/filings/2025/institution-snapshot-id",
             json={"institution_snapshot_id": "v3"},
         )
         assert res.status_code == 200

--- a/tests/api/routers/test_filing_api.py
+++ b/tests/api/routers/test_filing_api.py
@@ -180,8 +180,9 @@ class TestFilingApi:
     async def test_unauthed_patch_filing(self, app_fixture: FastAPI):
         client = TestClient(app_fixture)
 
-        res = client.patch(
-            "/v1/filing/institutions/1234567890/filings/2025/fields/institution_snapshot_id", json={"value": "v3"}
+        res = client.put(
+            "/v1/filing/institutions/1234567890/filings/2025/institution_snapshot_id",
+            json={"institution_snapshot_id": "v3"},
         )
         assert res.status_code == 403
 
@@ -199,25 +200,30 @@ class TestFilingApi:
 
         # no existing filing for endpoint
         get_filing_mock.return_value = None
-        res = client.patch(
-            "/v1/filing/institutions/1234567890/filings/2025/fields/institution_snapshot_id", json={"value": "v3"}
+        res = client.put(
+            "/v1/filing/institutions/1234567890/filings/2025/institution_snapshot_id",
+            json={"institution_snapshot_id": "v3"},
         )
         assert res.status_code == 204
 
         # no known field for endpoint
         get_filing_mock.return_value = filing_return
-        res = client.patch("/v1/filing/institutions/1234567890/filings/2024/fields/unknown_field", json={"value": "v3"})
-        assert res.status_code == 204
+        res = client.put(
+            "/v1/filing/institutions/1234567890/filings/2024/unknown_field", json={"institution_snapshot_id": "v3"}
+        )
+        assert res.status_code == 404
 
         # unallowed value data type
-        res = client.patch(
-            "/v1/filing/institutions/1234567890/filings/2025/fields/institution_snapshot_id", json={"value": ["1", "2"]}
+        res = client.put(
+            "/v1/filing/institutions/1234567890/filings/2025/institution_snapshot_id",
+            json={"institution_snapshot_id": ["1", "2"]},
         )
         assert res.status_code == 422
 
         # good
-        res = client.patch(
-            "/v1/filing/institutions/1234567890/filings/2025/fields/institution_snapshot_id", json={"value": "v3"}
+        res = client.put(
+            "/v1/filing/institutions/1234567890/filings/2025/institution_snapshot_id",
+            json={"institution_snapshot_id": "v3"},
         )
         assert res.status_code == 200
         assert res.json()["institution_snapshot_id"] == "v3"


### PR DESCRIPTION
Closes #98 

Changed generic @router.patch("/institutions/{lei}/filings/{period_name}/fields/{field_name} endpoint to be a put and specific to the institution_snapshot_id field.   Updated expected DTO to be { institution_snapshot_id: str } instead of a generic value: str | int | float | bool