### PR TITLE
Added dependency to check user lei list from token

### DIFF
--- a/src/routers/dependencies.py
+++ b/src/routers/dependencies.py
@@ -1,4 +1,5 @@
 import httpx
+import os
 
 from config import settings
 from http import HTTPStatus
@@ -10,3 +11,10 @@ def verify_lei(request: Request, lei: str) -> None:
     lei_obj = res.json()
     if not lei_obj["is_active"]:
         raise HTTPException(status_code=HTTPStatus.FORBIDDEN, detail=f"LEI {lei} is in an inactive state.")
+
+
+def verify_user_lei_relation(request: Request, lei: str = None) -> None:
+    if os.getenv("ENV", "LOCAL") != "LOCAL" and lei:
+        institutions = request.user.institutions
+        if lei not in institutions:
+            raise HTTPException(status_code=HTTPStatus.FORBIDDEN, detail=f"LEI {lei} is not associated with the user.")

--- a/src/routers/filing.py
+++ b/src/routers/filing.py
@@ -13,12 +13,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from starlette.authentication import requires
 
+from .dependencies import verify_user_lei_relation
+
 
 async def set_db(request: Request, session: Annotated[AsyncSession, Depends(get_session)]):
     request.state.db_session = session
 
 
-router = Router(dependencies=[Depends(set_db)])
+router = Router(dependencies=[Depends(set_db), Depends(verify_user_lei_relation)])
 
 
 @router.get("/periods", response_model=List[FilingPeriodDTO])

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -38,7 +38,7 @@ def authed_user_mock(auth_mock: Mock) -> Mock:
         "name": "test",
         "preferred_username": "test_user",
         "email": "test@local.host",
-        "institutions": "123456ABCDEF, 654321FEDCBA",
+        "institutions": ["123456ABCDEF", "654321FEDCBA"],
     }
     auth_mock.return_value = (
         AuthCredentials(["authenticated"]),

--- a/tests/api/routers/test_filing_api.py
+++ b/tests/api/routers/test_filing_api.py
@@ -250,10 +250,18 @@ class TestFilingApi:
         )
 
     def test_user_lei_association(
-        self, mocker: MockerFixture, app_fixture: FastAPI, authed_user_mock: Mock, get_filing_mock: Mock
+        self,
+        mocker: MockerFixture,
+        app_fixture: FastAPI,
+        authed_user_mock: Mock,
+        get_filing_mock: Mock,
+        get_filing_period_mock: Mock,
     ):
         mocker.patch.dict(os.environ, {"ENV": "TEST"})
         client = TestClient(app_fixture)
+        res = client.get("/v1/filing/periods")
+        assert res.status_code == 200
+
         res = client.get("/v1/filing/institutions/1234567890/filings/2024/")
         assert res.status_code == 403
         assert res.json()["detail"] == "LEI 1234567890 is not associated with the user."


### PR DESCRIPTION
Closes #102 

- Added verify_user_lei_relation which checks if the path lei is in the request.user.institutions list
- Made the check dependent on the ENV var not being LOCAL (for ease of dev testing)
- Updated the Router to use the dependency.  Dependency sets the lei as optional for the /periods endpoint (which doesn't care about lei checking, all others do)
- Created pytests to check dependency
- Moved the two dependency functions into a routers/dependencies.py file