### PR TITLE
added /{lei}/filings/{period_code} endpoint and pytest

### DIFF
--- a/src/sbl_filing_api/entities/repos/submission_repo.py
+++ b/src/sbl_filing_api/entities/repos/submission_repo.py
@@ -71,6 +71,13 @@ async def get_period_filings(session: AsyncSession, filing_period: str) -> List[
     return filings
 
 
+async def get_filings_by_user_and_period(session: AsyncSession, lei: str, filing_period: str) -> List[FilingDAO]:
+    filings = await query_helper(session, FilingDAO, lei=lei, filing_period=filing_period)
+    if filings:
+        filings = await populate_missing_tasks(session, filings)
+    return filings
+
+
 async def get_filing_period(session: AsyncSession, filing_period: str) -> FilingPeriodDAO:
     result = await query_helper(session, FilingPeriodDAO, code=filing_period)
     return result[0] if result else None

--- a/src/sbl_filing_api/routers/filing.py
+++ b/src/sbl_filing_api/routers/filing.py
@@ -47,6 +47,15 @@ async def get_filing(request: Request, lei: str, period_code: str):
     return res
 
 
+@router.get("/{lei}/filings/{period_code}", response_model=List[FilingDTO])
+@requires("authenticated")
+async def get_filings_by_user_and_period(request: Request, lei: str, period_code: str):
+    res = await repo.get_filings_by_user_and_period(request.state.db_session, lei, period_code)
+    if not res:
+        return JSONResponse(status_code=status.HTTP_204_NO_CONTENT, content=None)
+    return res
+
+
 @router.post("/institutions/{lei}/filings/{period_code}", response_model=FilingDTO)
 @requires("authenticated")
 async def post_filing(request: Request, lei: str, period_code: str):

--- a/tests/entities/repos/test_submission_repo.py
+++ b/tests/entities/repos/test_submission_repo.py
@@ -69,9 +69,17 @@ class TestSubmissionRepo:
             institution_snapshot_id="Snapshot-1",
             filing_period="2024",
         )
+        filing4 = FilingDAO(
+            id=4,
+            lei="ZYXWVUTSRQP",
+            institution_snapshot_id="Snapshot-1",
+            filing_period="2024",
+        )
+
         transaction_session.add(filing1)
         transaction_session.add(filing2)
         transaction_session.add(filing3)
+        transaction_session.add(filing4)
 
         filing_task1 = FilingTaskProgressDAO(
             id=1,
@@ -187,7 +195,7 @@ class TestSubmissionRepo:
 
     async def test_add_filing(self, transaction_session: AsyncSession):
         res = await repo.create_new_filing(transaction_session, lei="12345ABCDE", filing_period="2024")
-        assert res.id == 4
+        assert res.id == 5
         assert res.filing_period == "2024"
         assert res.lei == "12345ABCDE"
         assert res.institution_snapshot_id == "v1"
@@ -286,7 +294,7 @@ class TestSubmissionRepo:
 
     async def test_get_period_filings(self, query_session: AsyncSession, mocker: MockerFixture):
         results = await repo.get_period_filings(query_session, filing_period="2024")
-        assert len(results) == 3
+        assert len(results) == 4
         assert results[0].id == 1
         assert results[0].lei == "1234567890"
         assert results[0].filing_period == "2024"
@@ -499,6 +507,16 @@ class TestSubmissionRepo:
         assert submitter.submitter == "test2@cfpb.gov"
         assert submitter.submitter_name == "test2 submitter name"
         assert submitter.submitter_email == "test2@cfpb.gov"
+
+    async def test_get_filings_by_user_and_period(self, query_session: AsyncSession, mocker: MockerFixture):
+        results = await repo.get_filings_by_user_and_period(query_session, lei="ZYXWVUTSRQP", filing_period="2024")
+        assert len(results) == 2
+        assert results[0].id == 3
+        assert results[0].lei == "ZYXWVUTSRQP"
+        assert results[0].filing_period == "2024"
+        assert results[1].id == 4
+        assert results[1].lei == "ZYXWVUTSRQP"
+        assert results[1].filing_period == "2024"
 
     def get_error_json(self):
         df_columns = [


### PR DESCRIPTION
closes [#142 ](https://github.com/cfpb/sbl-filing-api/issues/142)
## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
