### PR TITLE
Updated update_submission to use upsert_helper`

### DIFF
--- a/src/sbl_filing_api/entities/repos/submission_repo.py
+++ b/src/sbl_filing_api/entities/repos/submission_repo.py
@@ -110,14 +110,7 @@ async def add_submission(
 
 async def update_submission(submission: SubmissionDAO, incoming_session: AsyncSession = None) -> SubmissionDAO:
     session = incoming_session if incoming_session else SessionLocal()
-    try:
-        new_sub = await session.merge(submission)
-        await session.commit()
-        return new_sub
-    except Exception as e:
-        await session.rollback()
-        logger.error(f"There was an exception storing the updated SubmissionDAO, rolling back transaction: {e}")
-        raise
+    return await upsert_helper(session, submission, SubmissionDAO)
 
 
 async def upsert_filing_period(session: AsyncSession, filing_period: FilingPeriodDTO) -> FilingPeriodDAO:


### PR DESCRIPTION
Closes #149 

Ran curl commands to upload multiple files to ensure each responded with the submission json, and then accepted each that validated.  Example submitter and accepter:
```
  "submitter": {
    "id": 25,
    "submitter": "631dbab3-4dcf-46bf-b283-55c18a3722e6",
    "submitter_name": "",
    "submitter_email": "admin1@local.host"
  },
  "accepter": {
    "id": 2,
    "accepter": "631dbab3-4dcf-46bf-b283-55c18a3722e6",
    "accepter_name": "",
    "accepter_email": "admin1@local.host",
    "acception_time": "2024-04-09T00:42:27.225838"
  }
  ```