### PR TITLE
Added an authentication check in dependency

### DIFF
--- a/src/sbl_filing_api/routers/dependencies.py
+++ b/src/sbl_filing_api/routers/dependencies.py
@@ -15,6 +15,9 @@ def verify_lei(request: Request, lei: str) -> None:
 
 def verify_user_lei_relation(request: Request, lei: str = None) -> None:
     if os.getenv("ENV", "LOCAL") != "LOCAL" and lei:
-        institutions = request.user.institutions
-        if lei not in institutions:
-            raise HTTPException(status_code=HTTPStatus.FORBIDDEN, detail=f"LEI {lei} is not associated with the user.")
+        if request.user.is_authenticated:
+            institutions = request.user.institutions
+            if lei not in institutions:
+                raise HTTPException(
+                    status_code=HTTPStatus.FORBIDDEN, detail=f"LEI {lei} is not associated with the user."
+                )

--- a/tests/api/routers/test_filing_api.py
+++ b/tests/api/routers/test_filing_api.py
@@ -379,6 +379,19 @@ class TestFilingApi:
             ANY, "1234567890", "2024", "Task-1", FilingTaskState.COMPLETED, authed_user_mock.return_value[1]
         )
 
+    def test_unauthed_user_lei_association(
+        self,
+        mocker: MockerFixture,
+        app_fixture: FastAPI,
+        unauthed_user_mock: Mock,
+        get_filing_mock: Mock,
+        get_filing_period_mock: Mock,
+    ):
+        client = TestClient(app_fixture)
+
+        res = client.get("/v1/filing/institutions/123456ABCDEF/filings/2024/")
+        assert res.status_code == 403
+
     def test_user_lei_association(
         self,
         mocker: MockerFixture,


### PR DESCRIPTION
Closes #135 

Added check for is_authenticated before trying to pull LEIs from the request.user.  This will ignore the LEI if the user is not authenticated, which will end up returning (from the @required decorator) a 403 Forbidden as normal now if the user token is expired.
