### PR TITLE
177 wip 204 no content response likely causing 500 error

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1366,7 +1366,6 @@ optional = false
 python-versions = ">=3.9"
 files = [
     {file = "pandas-2.2.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:90c6fca2acf139569e74e8781709dccb6fe25940488755716d1d354d6bc58bce"},
-    {file = "pandas-2.2.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c7adfc142dac335d8c1e0dcbd37eb8617eac386596eb9e1a1b77791cf2498238"},
     {file = "pandas-2.2.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4abfe0be0d7221be4f12552995e58723c7422c80a659da13ca382697de830c08"},
     {file = "pandas-2.2.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8635c16bf3d99040fdf3ca3db669a7250ddf49c55dc4aa8fe0ae0fa8d6dcc1f0"},
     {file = "pandas-2.2.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:40ae1dffb3967a52203105a077415a86044a2bea011b5f321c6aa64b379a3f51"},
@@ -1387,7 +1386,6 @@ files = [
     {file = "pandas-2.2.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:43498c0bdb43d55cb162cdc8c06fac328ccb5d2eabe3cadeb3529ae6f0517c32"},
     {file = "pandas-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:d187d355ecec3629624fccb01d104da7d7f391db0311145817525281e2804d23"},
     {file = "pandas-2.2.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0ca6377b8fca51815f382bd0b697a0814c8bda55115678cbc94c30aacbb6eff2"},
-    {file = "pandas-2.2.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9057e6aa78a584bc93a13f0a9bf7e753a5e9770a30b4d758b8d5f2a62a9433cd"},
     {file = "pandas-2.2.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:001910ad31abc7bf06f49dcc903755d2f7f3a9186c0c040b827e522e9cef0863"},
     {file = "pandas-2.2.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66b479b0bd07204e37583c191535505410daa8df638fd8e75ae1b383851fe921"},
     {file = "pandas-2.2.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:a77e9d1c386196879aa5eb712e77461aaee433e54c68cf253053a73b7e49c33a"},
@@ -2016,7 +2014,7 @@ requests = "^2.31.0"
 type = "git"
 url = "https://github.com/cfpb/regtech-api-commons.git"
 reference = "HEAD"
-resolved_reference = "e526c1ee2778c1f96a75d85ac9d22362da67dcb9"
+resolved_reference = "7f8eecdc62e501b0fdc5831453b8ee1f52884430"
 
 [[package]]
 name = "regtech-data-validator"
@@ -2037,7 +2035,7 @@ tabulate = "^0.9.0"
 type = "git"
 url = "https://github.com/cfpb/regtech-data-validator.git"
 reference = "HEAD"
-resolved_reference = "505350764c937eb2daa6c2efc2f350a9cb6bd48b"
+resolved_reference = "a3c0f67a906397e8be81913ffe8e49dba79045d7"
 
 [[package]]
 name = "regtech-regex"
@@ -2055,7 +2053,7 @@ pyyaml = "^6.0.1"
 type = "git"
 url = "https://github.com/cfpb/regtech-regex.git"
 reference = "HEAD"
-resolved_reference = "730c9c0b79468c7884fd7b4c5d2459fc2461c12c"
+resolved_reference = "7429ca940eecf1a8ebb33255e1d95b6db1d96431"
 
 [[package]]
 name = "requests"
@@ -2269,7 +2267,7 @@ files = [
 ]
 
 [package.dependencies]
-greenlet = {version = "!=0.4.17", markers = "platform_machine == \"win32\" or platform_machine == \"WIN32\" or platform_machine == \"AMD64\" or platform_machine == \"amd64\" or platform_machine == \"x86_64\" or platform_machine == \"ppc64le\" or platform_machine == \"aarch64\""}
+greenlet = {version = "!=0.4.17", markers = "platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\""}
 typing-extensions = ">=4.6.0"
 
 [package.extras]

--- a/src/sbl_filing_api/entities/models/dto.py
+++ b/src/sbl_filing_api/entities/models/dto.py
@@ -1,4 +1,3 @@
-from fastapi.exceptions import RequestValidationError
 from sbl_filing_api.config import regex_configs
 from datetime import datetime
 from typing import Dict, Any, List
@@ -66,13 +65,11 @@ class ContactInfoDTO(BaseModel):
         if self.email:
             match = regex_configs.email.regex.match(self.email)
             if not match:
-                raise RequestValidationError(f"Invalid email {self.email}. {regex_configs.email.error_text}")
+                raise ValueError(f"Invalid email {self.email}. {regex_configs.email.error_text}")
         if self.phone_number:
             match = regex_configs.phone_number.regex.match(self.phone_number)
             if not match:
-                raise RequestValidationError(
-                    f"Invalid phone number {self.phone_number}. {regex_configs.phone_number.error_text}"
-                )
+                raise ValueError(f"Invalid phone number {self.phone_number}. {regex_configs.phone_number.error_text}")
         return self
 
 

--- a/src/sbl_filing_api/entities/models/dto.py
+++ b/src/sbl_filing_api/entities/models/dto.py
@@ -1,3 +1,4 @@
+from fastapi.exceptions import RequestValidationError
 from sbl_filing_api.config import regex_configs
 from datetime import datetime
 from typing import Dict, Any, List
@@ -65,11 +66,13 @@ class ContactInfoDTO(BaseModel):
         if self.email:
             match = regex_configs.email.regex.match(self.email)
             if not match:
-                raise ValueError(f"Invalid email {self.email}. {regex_configs.email.error_text}")
+                raise RequestValidationError(f"Invalid email {self.email}. {regex_configs.email.error_text}")
         if self.phone_number:
             match = regex_configs.phone_number.regex.match(self.phone_number)
             if not match:
-                raise ValueError(f"Invalid phone number {self.phone_number}. {regex_configs.phone_number.error_text}")
+                raise RequestValidationError(
+                    f"Invalid phone number {self.phone_number}. {regex_configs.phone_number.error_text}"
+                )
         return self
 
 

--- a/src/sbl_filing_api/entities/repos/submission_repo.py
+++ b/src/sbl_filing_api/entities/repos/submission_repo.py
@@ -80,11 +80,6 @@ async def get_filing_tasks(session: AsyncSession) -> List[FilingTaskDAO]:
     return await query_helper(session, FilingTaskDAO)
 
 
-async def get_contact_info(session: AsyncSession, lei: str, filing_period: str) -> ContactInfoDAO:
-    filing = await get_filing(session, lei=lei, filing_period=filing_period)
-    return filing.contact_info
-
-
 async def get_user_action(session: AsyncSession, id: int) -> UserActionDAO:
     result = await query_helper(session, UserActionDAO, id=id)
     return result[0] if result else None

--- a/tests/api/routers/test_filing_api.py
+++ b/tests/api/routers/test_filing_api.py
@@ -989,7 +989,7 @@ class TestFilingApi:
         res = client.put(
             "/v1/filing/institutions/1234567890ZXWVUTSR00/filings/2024/contact-info", json=contact_info_json
         )
-        assert res.json()["error_detail"] == f"Invalid email test_email. {regex_configs.email.error_text}"
+        assert f"Value error, Invalid email test_email. {regex_configs.email.error_text}" in res.json()["error_detail"]
         assert res.status_code == 422
 
     def test_contact_info_invalid_phone_number(
@@ -1013,5 +1013,8 @@ class TestFilingApi:
         res = client.put(
             "/v1/filing/institutions/1234567890ZXWVUTSR00/filings/2024/contact-info", json=contact_info_json
         )
-        assert res.json()["error_detail"] == f"Invalid phone number 1123456789. {regex_configs.phone_number.error_text}"
+        assert (
+            f"Value error, Invalid phone number 1123456789. {regex_configs.phone_number.error_text}"
+            in res.json()["error_detail"]
+        )
         assert res.status_code == 422

--- a/tests/api/routers/test_filing_api.py
+++ b/tests/api/routers/test_filing_api.py
@@ -540,7 +540,9 @@ class TestFilingApi:
         res = client.get("/v1/filing/institutions/1234567890ZXWVUTSR00/filings/2024/contact-info")
         assert res.status_code == 403
 
-    async def test_get_contact_info(self, mocker: MockerFixture, app_fixture: FastAPI, authed_user_mock: Mock, get_filing_mock):
+    async def test_get_contact_info(
+        self, mocker: MockerFixture, app_fixture: FastAPI, authed_user_mock: Mock, get_filing_mock
+    ):
         client = TestClient(app_fixture)
         res = client.get("/v1/filing/institutions/1234567890ZXWVUTSR00/filings/2024/contact-info")
         result = res.json()
@@ -987,10 +989,7 @@ class TestFilingApi:
         res = client.put(
             "/v1/filing/institutions/1234567890ZXWVUTSR00/filings/2024/contact-info", json=contact_info_json
         )
-        assert (
-            res.json()["error_detail"][0]["msg"]
-            == f"Value error, Invalid email test_email. {regex_configs.email.error_text}"
-        )
+        assert res.json()["error_detail"] == f"Invalid email test_email. {regex_configs.email.error_text}"
         assert res.status_code == 422
 
     def test_contact_info_invalid_phone_number(
@@ -1014,8 +1013,5 @@ class TestFilingApi:
         res = client.put(
             "/v1/filing/institutions/1234567890ZXWVUTSR00/filings/2024/contact-info", json=contact_info_json
         )
-        assert (
-            res.json()["error_detail"][0]["msg"]
-            == f"Value error, Invalid phone number 1123456789. {regex_configs.phone_number.error_text}"
-        )
+        assert res.json()["error_detail"] == f"Invalid phone number 1123456789. {regex_configs.phone_number.error_text}"
         assert res.status_code == 422

--- a/tests/api/routers/test_filing_api.py
+++ b/tests/api/routers/test_filing_api.py
@@ -63,7 +63,7 @@ class TestFilingApi:
 
         get_filing_mock.return_value = None
         res = client.get("/v1/filing/institutions/1234567890ABCDEFGH00/filings/2024/")
-        assert res.status_code == 204
+        assert res.status_code == 404
 
     def test_unauthed_post_filing(self, app_fixture: FastAPI):
         client = TestClient(app_fixture)
@@ -241,7 +241,7 @@ class TestFilingApi:
         mock.return_value = None
         res = client.get("/v1/filing/institutions/1234567890ZXWVUTSR00/filings/2024/submissions/1")
         mock.assert_called_with(ANY, 1)
-        assert res.status_code == 204
+        assert res.status_code == 404
 
     def test_authed_upload_file(
         self,
@@ -540,22 +540,7 @@ class TestFilingApi:
         res = client.get("/v1/filing/institutions/1234567890ZXWVUTSR00/filings/2024/contact-info")
         assert res.status_code == 403
 
-    async def test_get_contact_info(self, mocker: MockerFixture, app_fixture: FastAPI, authed_user_mock: Mock):
-        mock = mocker.patch("sbl_filing_api.entities.repos.submission_repo.get_contact_info")
-        mock.return_value = ContactInfoDAO(
-            id=1,
-            filing=1,
-            first_name="test_first_name_1",
-            last_name="test_last_name_1",
-            hq_address_street_1="address street 1",
-            hq_address_street_2="",
-            hq_address_city="Test City",
-            hq_address_state="TS",
-            hq_address_zip="12345",
-            phone_number="112-345-6789",
-            email="name_1@email.test",
-        )
-
+    async def test_get_contact_info(self, mocker: MockerFixture, app_fixture: FastAPI, authed_user_mock: Mock, get_filing_mock):
         client = TestClient(app_fixture)
         res = client.get("/v1/filing/institutions/1234567890ZXWVUTSR00/filings/2024/contact-info")
         result = res.json()
@@ -565,17 +550,17 @@ class TestFilingApi:
         assert result["first_name"] == "test_first_name_1"
         assert result["last_name"] == "test_last_name_1"
         assert result["hq_address_street_1"] == "address street 1"
-        assert result["hq_address_street_2"] == ""
+        assert result["hq_address_street_2"] == "address street 2"
         assert result["hq_address_city"] == "Test City"
         assert result["hq_address_state"] == "TS"
         assert result["hq_address_zip"] == "12345"
         assert result["phone_number"] == "112-345-6789"
-        assert result["email"] == "name_1@email.test"
+        assert result["email"] == "test1@cfpb.gov"
 
         # no contact_info for endpoint
-        mock.return_value = None
+        get_filing_mock.return_value = None
         res = client.get("/v1/filing/institutions/1234567890ZXWVUTSR00/filings/2024/contact-info")
-        assert res.status_code == 204
+        assert res.status_code == 404
 
     async def test_unauthed_put_contact_info(self, mocker: MockerFixture, app_fixture: FastAPI, unauthed_user_mock):
         contact_info_json = {
@@ -979,7 +964,7 @@ class TestFilingApi:
         client = TestClient(app_fixture)
         res = client.get("/v1/filing/institutions/1234567890ZXWVUTSR00/filings/2024/submissions/1/report")
         sub_mock.assert_called_with(ANY, 1)
-        assert res.status_code == 204
+        assert res.status_code == 404
 
         os.unlink(temp_file.name)
 

--- a/tests/entities/repos/test_submission_repo.py
+++ b/tests/entities/repos/test_submission_repo.py
@@ -462,21 +462,21 @@ class TestSubmissionRepo:
         await query_updated_dao()
 
     async def test_get_contact_info(self, query_session: AsyncSession):
-        res = await repo.get_contact_info(session=query_session, lei="ABCDEFGHIJ", filing_period="2024")
+        res = await repo.get_filing(session=query_session, lei="ABCDEFGHIJ", filing_period="2024")
 
-        assert res.id == 2
-        assert res.filing == 2
-        assert res.first_name == "test_first_name_2"
-        assert res.last_name == "test_last_name_2"
-        assert res.hq_address_street_1 == "address street 2"
-        assert res.hq_address_street_2 == ""
-        assert res.hq_address_street_3 == ""
-        assert res.hq_address_street_4 == ""
-        assert res.hq_address_city == "Test City 2"
-        assert res.hq_address_state == "TS"
-        assert res.hq_address_zip == "12345"
-        assert res.phone_number == "212-345-6789"
-        assert res.email == "test2@cfpb.gov"
+        assert res.contact_info.id == 2
+        assert res.contact_info.filing == 2
+        assert res.contact_info.first_name == "test_first_name_2"
+        assert res.contact_info.last_name == "test_last_name_2"
+        assert res.contact_info.hq_address_street_1 == "address street 2"
+        assert res.contact_info.hq_address_street_2 == ""
+        assert res.contact_info.hq_address_street_3 == ""
+        assert res.contact_info.hq_address_street_4 == ""
+        assert res.contact_info.hq_address_city == "Test City 2"
+        assert res.contact_info.hq_address_state == "TS"
+        assert res.contact_info.hq_address_zip == "12345"
+        assert res.contact_info.phone_number == "212-345-6789"
+        assert res.contact_info.email == "test2@cfpb.gov"
 
     async def test_create_contact_info(self, transaction_session: AsyncSession):
         filing = await repo.update_contact_info(


### PR DESCRIPTION
Closes #177 
Closes #189 

Changes the GET /latest to set the status on the response object to 204 instead of returning a JSONResponse with status 204.  This was causing the large exception to appear due to a bug in a library called h11 that starlette uses.

Updated the GETs that check for objects, like Filings, to return 404s if those objects don't exist.  Uses the same method of setting the response.status_code vs raising an exception or returning a Response/JSONResponse.

Updated the ContactInfoDTO to use a RequestValidationException that can be caught by the exception handlers set in main.py so that the response error_details will be consistent with our other exceptions.  ValueError is a general python error that wasn't being handle in the same manner.  Could potentially add another exception handler for it in api-commons?  Or just go with the RequestValidationException?