### PR TITLE
feat: run as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,6 @@ WORKDIR /usr/app/src
 
 EXPOSE 8888
 
+USER sbl
+
 CMD ["python", "sbl_filing_api/main.py"]


### PR DESCRIPTION
Prisma rightfully complains about containers running as root. The following change adds the USER instruction to specify the user the container will run as.

## Testing

1. Pushed the updated image to ECR and ran in dev. The pod returns typical 200 codes, @jcadam14 ran more thorough GET and PUT requests with success.
