### PR TITLE
Removed counter to id code

### DIFF
--- a/src/sbl_filing_api/entities/models/dto.py
+++ b/src/sbl_filing_api/entities/models/dto.py
@@ -28,13 +28,6 @@ class SubmissionDTO(BaseModel):
     submitter: UserActionDTO
     accepter: UserActionDTO | None = None
 
-    @model_validator(mode="after")
-    def validate_fi(self) -> "SubmissionDTO":
-        print(f"Self: {self}")
-        self.id = self.counter
-        print(f"Self: {self}")
-        return self
-
 
 class FilingTaskDTO(BaseModel):
     model_config = ConfigDict(from_attributes=True)

--- a/tests/api/routers/test_filing_api.py
+++ b/tests/api/routers/test_filing_api.py
@@ -977,7 +977,8 @@ class TestFilingApi:
         )
 
         assert res.json()["state"] == "SUBMISSION_ACCEPTED"
-        assert res.json()["id"] == 4
+        assert res.json()["id"] == 1
+        assert res.json()["counter"] == 4
         assert res.json()["accepter"]["id"] == 3
         assert res.json()["accepter"]["user_id"] == "1234-5678-ABCD-EFGH"
         assert res.json()["accepter"]["user_name"] == "test accepter"


### PR DESCRIPTION
Closes #507 

This was tested out in devpub (current image there now).  Counter is correctly being used by the frontend, backend no longer has need for the logic to set the submission id to the counter.