### PR TITLE
dep: bump pyproject sqlalchemy to 2.0.39

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3042,4 +3042,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4"
-content-hash = "edb8af6aeea0944c8d79ba53458b652188b9e058b54cef08762c8d256ac20ae6"
+content-hash = "6a9a5f1a713358602f7a7ff08b6751d1fdfca73cf43add1a956d5fca8160d98e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{ include = "sbl_filing_api", from = "src" }]
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4"
-sqlalchemy = "^2.0.35"
+sqlalchemy = "^2.0.39"
 psycopg2-binary = "^2.9.9"
 asyncpg = "^0.30.0"
 regtech-api-commons = {git = "https://github.com/cfpb/regtech-api-commons.git"}


### PR DESCRIPTION
lockfile already had 2.0.39, only the toml file needed update, hence the tiny change to the lockfile

closes #575 